### PR TITLE
Improve view error handling and add tests

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -49,7 +49,7 @@ func NewNoteListModel(
 ) (*NoteListModel, error) {
 	files, err := s.ViewManager.GetFilesByView(viewName, s.Vault)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load files for view %q: %w", viewName, err)
 	}
 
 	items := ParseNoteFiles(files, s.Vault, false)
@@ -412,7 +412,13 @@ func (m *NoteListModel) refresh() tea.Cmd {
 }
 
 func (m *NoteListModel) refreshItems() tea.Cmd {
-	files, _ := m.state.ViewManager.GetFilesByView(m.viewName, m.state.Vault)
+	files, err := m.state.ViewManager.GetFilesByView(m.viewName, m.state.Vault)
+	if err != nil {
+		m.list.NewStatusMessage(
+			statusStyle(fmt.Sprintf("Failed to load %s view: %v", m.viewName, err)),
+		)
+		return nil
+	}
 	items := ParseNoteFiles(files, m.state.Vault, m.showDetails)
 	sortedItems := sortItems(castToListItems(items), m.sortField, m.sortOrder)
 	return m.list.SetItems(sortedItems)

--- a/internal/tui/pinList/submodels/sublist/sublist.go
+++ b/internal/tui/pinList/submodels/sublist/sublist.go
@@ -36,9 +36,15 @@ func NewSubListModel(s *state.State) SubListModel {
 	// l.DisableQuitKeybindings()
 	l.AdditionalFullHelpKeys = func() []key.Binding { return fullHelp(listKeys) }
 
-	files, _ := s.ViewManager.GetFilesByView("default", s.Vault)
-	items := notes.ParseNoteFiles(files, s.Vault, false)
-	l.SetItems(items)
+	files, err := s.ViewManager.GetFilesByView("default", s.Vault)
+	if err != nil {
+		l.NewStatusMessage(
+			statusMessageStyle(fmt.Sprintf("Failed to load default view: %v", err)),
+		)
+	} else {
+		items := notes.ParseNoteFiles(files, s.Vault, false)
+		l.SetItems(items)
+	}
 
 	return SubListModel{
 		List:         l,

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -130,22 +130,23 @@ func (vm *ViewManager) GetFilesByView(
 	m, ok := vm.Views[viewFlag]
 	if !ok {
 		availableViews := vm.GetAvailableViews()
-		panic(fmt.Errorf(
+		return nil, fmt.Errorf(
 			"invalid view: %s. Available views are: %s",
 			viewFlag,
 			availableViews,
-		))
-
+		)
 	}
+
 	if len(m.ExcludeDirs) == 0 {
 		excludeDirs = defaultExcludeDirs
 	} else {
 		excludeDirs = m.ExcludeDirs
 	}
-	if len(excludeFiles) == 0 {
+
+	if len(m.ExcludeFiles) == 0 {
 		excludeFiles = defaultExcludeFiles
 	} else {
-		excludeDirs = m.ExcludeFiles
+		excludeFiles = m.ExcludeFiles
 	}
 
 	return vm.Handler.WalkFiles(excludeDirs, excludeFiles, viewFlag)

--- a/internal/views/views_test.go
+++ b/internal/views/views_test.go
@@ -1,0 +1,114 @@
+package views
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/handler"
+)
+
+func TestGetFilesByView_DefaultAndArchive(t *testing.T) {
+	vaultDir := t.TempDir()
+
+	mustMkdirAll(t, filepath.Join(vaultDir, "archive", "project"))
+	mustMkdirAll(t, filepath.Join(vaultDir, "trash", "project"))
+	mustMkdirAll(t, filepath.Join(vaultDir, "notes"))
+
+	keepPath := filepath.Join(vaultDir, "notes", "keep.md")
+	skipPath := filepath.Join(vaultDir, "notes", "skip.md")
+	archivedPath := filepath.Join(vaultDir, "archive", "project", "archived.md")
+	trashedPath := filepath.Join(vaultDir, "trash", "project", "trashed.md")
+
+	mustWriteFile(t, keepPath)
+	mustWriteFile(t, skipPath)
+	mustWriteFile(t, archivedPath)
+	mustWriteFile(t, trashedPath)
+
+	h := handler.NewFileHandler(vaultDir)
+	vm := NewViewManager(h, vaultDir)
+
+	vm.Views["custom"] = View{
+		ExcludeDirs:  []string{},
+		ExcludeFiles: []string{"skip.md"},
+		OrphanOnly:   false,
+	}
+
+	t.Run("default view excludes archive and trash", func(t *testing.T) {
+		files, err := vm.GetFilesByView("default", vaultDir)
+		if err != nil {
+			t.Fatalf("GetFilesByView returned error: %v", err)
+		}
+
+		if !contains(files, keepPath) {
+			t.Fatalf("default view missing expected file %s", keepPath)
+		}
+
+		if contains(files, archivedPath) {
+			t.Fatalf("default view unexpectedly contained archived file %s", archivedPath)
+		}
+
+		if contains(files, trashedPath) {
+			t.Fatalf("default view unexpectedly contained trashed file %s", trashedPath)
+		}
+	})
+
+	t.Run("archive view returns archived notes", func(t *testing.T) {
+		files, err := vm.GetFilesByView("archive", vaultDir)
+		if err != nil {
+			t.Fatalf("GetFilesByView returned error: %v", err)
+		}
+
+		if !contains(files, archivedPath) {
+			t.Fatalf("archive view missing expected file %s", archivedPath)
+		}
+
+		if contains(files, keepPath) {
+			t.Fatalf("archive view unexpectedly contained active file %s", keepPath)
+		}
+	})
+
+	t.Run("custom view excludes configured files", func(t *testing.T) {
+		files, err := vm.GetFilesByView("custom", vaultDir)
+		if err != nil {
+			t.Fatalf("GetFilesByView returned error: %v", err)
+		}
+
+		if contains(files, skipPath) {
+			t.Fatalf("custom view unexpectedly contained excluded file %s", skipPath)
+		}
+
+		if !contains(files, keepPath) {
+			t.Fatalf("custom view missing expected file %s", keepPath)
+		}
+	})
+
+	t.Run("invalid view returns error", func(t *testing.T) {
+		if _, err := vm.GetFilesByView("unknown", vaultDir); err == nil {
+			t.Fatal("expected error for unknown view, got nil")
+		}
+	})
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("failed to create directory %s: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("# test\n"), 0o644); err != nil {
+		t.Fatalf("failed to write file %s: %v", path, err)
+	}
+}
+
+func contains(values []string, target string) bool {
+	for _, v := range values {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- return descriptive errors from `GetFilesByView` and ensure exclude file lists are respected
- surface load failures in the note list and pin sublist UIs
- add regression coverage for default, archive, custom, and invalid views

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0a467f8b08325b8462255170d9b39