### PR TITLE
Expand editor validation coverage for editor selection

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,93 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Paintersrp/an/internal/config"
+)
+
+func TestLoadAcceptsSupportedEditors(t *testing.T) {
+	editors := []string{"nvim", "obsidian", "vscode", "vim", "nano"}
+
+	for _, editor := range editors {
+		editor := editor
+		t.Run(editor, func(t *testing.T) {
+			home := t.TempDir()
+			configPath := config.GetConfigPath(home)
+
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatalf("failed to create config directory: %v", err)
+			}
+
+			cfgData := map[string]any{
+				"vaultdir":         filepath.Join(home, "vault"),
+				"editor":           editor,
+				"nvimargs":         "",
+				"fsmode":           "strict",
+				"pinned_file":      "",
+				"pinned_task_file": "",
+				"subdirs":          []string{},
+			}
+
+			data, err := yaml.Marshal(cfgData)
+			if err != nil {
+				t.Fatalf("failed to marshal config data: %v", err)
+			}
+
+			if err := os.WriteFile(configPath, data, 0o644); err != nil {
+				t.Fatalf("failed to write config file: %v", err)
+			}
+
+			cfg, err := config.Load(home)
+			if err != nil {
+				t.Fatalf("expected load to succeed for editor %q: %v", editor, err)
+			}
+
+			if cfg.Editor != editor {
+				t.Fatalf("expected editor %q, got %q", editor, cfg.Editor)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsUnsupportedEditor(t *testing.T) {
+	home := t.TempDir()
+	configPath := config.GetConfigPath(home)
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("failed to create config directory: %v", err)
+	}
+
+	cfgData := map[string]any{
+		"vaultdir":         filepath.Join(home, "vault"),
+		"editor":           "unsupported", // ensure validation fails
+		"nvimargs":         "",
+		"fsmode":           "strict",
+		"pinned_file":      "",
+		"pinned_task_file": "",
+		"subdirs":          []string{},
+	}
+
+	data, err := yaml.Marshal(cfgData)
+	if err != nil {
+		t.Fatalf("failed to marshal config data: %v", err)
+	}
+
+	if err := os.WriteFile(configPath, data, 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	_, err = config.Load(home)
+	if err == nil {
+		t.Fatal("expected load to fail for unsupported editor")
+	}
+
+	if !strings.Contains(err.Error(), "invalid editor") {
+		t.Fatalf("expected invalid editor error, got %v", err)
+	}
+}

--- a/internal/tui/initialize/init-prompt.go
+++ b/internal/tui/initialize/init-prompt.go
@@ -136,6 +136,11 @@ func (m InitPromptModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					PinnedTaskFile: defaults[6],
 				}
 
+				if err := config.ValidateEditor(cfg.Editor); err != nil {
+					fmt.Println(err)
+					return m, nil
+				}
+
 				cfgErr := cfg.Save()
 				if cfgErr != nil {
 					panic(cfgErr)

--- a/internal/tui/settings/list.go
+++ b/internal/tui/settings/list.go
@@ -163,14 +163,12 @@ func (m ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 
-				m.config.Editor = c
-				m.editorSelectActive = false
-
-				saveErr := m.config.Save()
-				if saveErr != nil {
-					fmt.Println("Failed to save config file, exiting...")
-					os.Exit(1)
+				if err := m.config.ChangeEditor(c); err != nil {
+					m.list.NewStatusMessage(statusMessageStyle(err.Error()))
+					return m, nil
 				}
+
+				m.editorSelectActive = false
 
 				index := m.list.Index()
 				items := m.list.Items()
@@ -254,21 +252,26 @@ func (m ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 
 				inputValue := m.configInput.Input.Value()
-				switch title {
-				case "VaultDir":
-					m.config.VaultDir = inputValue
-				case "Editor":
-					m.config.Editor = inputValue
-				case "NvimArgs":
-					m.config.NvimArgs = inputValue
-				case "MoleculeMode":
-					m.config.FileSystemMode = inputValue
-				}
+				if title == "Editor" {
+					if err := m.config.ChangeEditor(inputValue); err != nil {
+						m.list.NewStatusMessage(statusMessageStyle(err.Error()))
+						return m, nil
+					}
+				} else {
+					switch title {
+					case "VaultDir":
+						m.config.VaultDir = inputValue
+					case "NvimArgs":
+						m.config.NvimArgs = inputValue
+					case "MoleculeMode":
+						m.config.FileSystemMode = inputValue
+					}
 
-				err := m.config.Save()
-				if err != nil {
-					fmt.Println("Failed to save config file, exiting...")
-					os.Exit(1)
+					err := m.config.Save()
+					if err != nil {
+						fmt.Println("Failed to save config file, exiting...")
+						os.Exit(1)
+					}
 				}
 
 				index := m.list.Index()


### PR DESCRIPTION
## Summary
- allow all TUI editors (obsidian, vscode, vim, nano) via a shared validation helper
- reuse `config.ChangeEditor` when updating the editor from interactive flows
- add config loading tests that cover supported and unsupported editors

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0a9946fc083259a1954276e9120b7