### PR TITLE
Add parser and templater unit tests and document go test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ When the Bubble Tea interface opens you will see a scrollable list of notes, a p
 
 Run `an --help` or any subcommand with `--help` to explore the rest of the command surface (journal, todo, settings, pin management, symlinks, etc.).
 
+## Testing
+
+Run the unit suite before sending a pull request to confirm core flows still pass:
+
+```bash
+go test ./...
+```
+
+This exercises the configuration loader, view selection helpers, the Markdown parser, and the templating system so regressions in those critical packages are caught early.
+
 ## Roadmap & Further Reading
 
 For upcoming features, architecture notes, and broader project context, read the [Planning roadmap](Planning%20v3.md) document in the repository root.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,89 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParserWalkExtractsTasksAndTags(t *testing.T) {
+	dir := t.TempDir()
+	notePath := filepath.Join(dir, "note.md")
+	content := `# Title
+- [ ] first task
+- [x] completed task
+- [ ]    
+tags:
+- project/foo
+- project/foo
+- weekly
+`
+
+	if err := os.WriteFile(notePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write note: %v", err)
+	}
+
+	p := NewParser(dir)
+	if err := p.Walk(); err != nil {
+		t.Fatalf("Walk returned error: %v", err)
+	}
+
+	var (
+		foundUnchecked bool
+		foundChecked   bool
+	)
+
+	for _, task := range p.TaskHandler.Tasks {
+		switch task.Content {
+		case "first task":
+			if task.Status != "unchecked" {
+				t.Fatalf("expected first task to be unchecked, got %q", task.Status)
+			}
+			foundUnchecked = true
+		case "completed task":
+			if task.Status != "checked" {
+				t.Fatalf("expected completed task to be checked, got %q", task.Status)
+			}
+			foundChecked = true
+		}
+	}
+
+	if !foundUnchecked || !foundChecked {
+		t.Fatalf("expected to find both tracked tasks, got %#v", p.TaskHandler.Tasks)
+	}
+
+	if got := p.TagHandler.TagCounts["project/foo"]; got != 2 {
+		t.Fatalf("expected tag 'project/foo' to be counted twice, got %d", got)
+	}
+
+	if got := p.TagHandler.TagCounts["weekly"]; got != 1 {
+		t.Fatalf("expected tag 'weekly' to be counted once, got %d", got)
+	}
+
+	if len(p.TagHandler.TagList) != 2 {
+		t.Fatalf("expected TagList to only contain unique tags, got %#v", p.TagHandler.TagList)
+	}
+}
+
+func TestTaskHandlerParseTaskIgnoresEmptyContent(t *testing.T) {
+	handler := NewTaskHandler()
+	handler.ParseTask("[ ]   ")
+
+	if len(handler.Tasks) != 0 {
+		t.Fatalf("expected no tasks to be added for empty content, got %#v", handler.Tasks)
+	}
+}
+
+func TestTagHandlerParseTagIncrementsCounts(t *testing.T) {
+	handler := NewTagHandler()
+	handler.ParseTag("project/foo")
+	handler.ParseTag("project/foo")
+
+	if handler.TagCounts["project/foo"] != 2 {
+		t.Fatalf("expected tag count to increment to 2, got %d", handler.TagCounts["project/foo"])
+	}
+
+	if len(handler.TagList) != 1 {
+		t.Fatalf("expected TagList to deduplicate entries, got %#v", handler.TagList)
+	}
+}

--- a/internal/templater/templater_test.go
+++ b/internal/templater/templater_test.go
@@ -1,0 +1,106 @@
+package templater
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewTemplaterRegistersUserTemplate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	templatesDir := filepath.Join(os.Getenv("HOME"), ".an", "templates")
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
+		t.Fatalf("failed to create user template directory: %v", err)
+	}
+
+	customTemplatePath := filepath.Join(templatesDir, "custom.tmpl")
+	if err := os.WriteFile(customTemplatePath, []byte("Title: {{.Title}}"), 0o644); err != nil {
+		t.Fatalf("failed to write user template: %v", err)
+	}
+
+	prevValue, hadPrev := AvailableTemplates["custom"]
+	defer func() {
+		if hadPrev {
+			AvailableTemplates["custom"] = prevValue
+		} else {
+			delete(AvailableTemplates, "custom")
+		}
+	}()
+
+	tmpl, err := NewTemplater()
+	if err != nil {
+		t.Fatalf("NewTemplater returned error: %v", err)
+	}
+
+	tpl, ok := tmpl.templates["custom"]
+	if !ok {
+		t.Fatalf("expected custom template to be registered: %#v", tmpl.templates)
+	}
+
+	if tpl.FilePath != customTemplatePath {
+		t.Fatalf("expected template path %q, got %q", customTemplatePath, tpl.FilePath)
+	}
+}
+
+func TestTemplateMapLoadTemplates(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "user.tmpl"), []byte("content"), 0o644); err != nil {
+		t.Fatalf("failed to create template: %v", err)
+	}
+
+	m := make(TemplateMap)
+	if err := m.loadTemplates(dir); err != nil {
+		t.Fatalf("loadTemplates returned error: %v", err)
+	}
+
+	tpl, ok := m["user"]
+	if !ok {
+		t.Fatal("expected template named 'user' to be loaded")
+	}
+
+	if tpl.FilePath == "" {
+		t.Fatal("expected template FilePath to be recorded")
+	}
+}
+
+func TestGenerateTagsAndDateDefaultTemplate(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+
+	templater := &Templater{}
+	date, tags := templater.GenerateTagsAndDate("roadmap")
+
+	if len(date) == 0 {
+		t.Fatal("expected generated date to be non-empty")
+	}
+
+	if len(tags) != 0 {
+		t.Fatalf("expected non-daily template to have zero tags, got %#v", tags)
+	}
+}
+
+func TestExecuteMissingTemplate(t *testing.T) {
+	templater := &Templater{templates: make(TemplateMap)}
+
+	if _, err := templater.Execute("missing", TemplateData{}); err == nil {
+		t.Fatal("expected error when executing missing template, got nil")
+	}
+}
+
+func TestTemplaterExecuteRendersTemplate(t *testing.T) {
+	templater := &Templater{templates: TemplateMap{
+		"custom": {
+			Content: "Title: {{.Title}}",
+		},
+	}}
+
+	rendered, err := templater.Execute("custom", TemplateData{Title: "Rendered"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if !strings.Contains(rendered, "Rendered") {
+		t.Fatalf("expected rendered template to include title, got %q", rendered)
+	}
+}

--- a/internal/views/views_test.go
+++ b/internal/views/views_test.go
@@ -90,6 +90,42 @@ func TestGetFilesByView_DefaultAndArchive(t *testing.T) {
 	})
 }
 
+func TestGetTitleForView(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		viewFlag  string
+		sortField int
+		sortOrder int
+		want      string
+	}{{
+		name:      "known view and sort field ascending",
+		viewFlag:  "default",
+		sortField: 0,
+		sortOrder: 0,
+		want:      "✅ - All View \nSort: Title (Ascending)",
+	}, {
+		name:      "unknown view falls back to default prefix",
+		viewFlag:  "mystery",
+		sortField: 5,
+		sortOrder: 1,
+		want:      "✅ - All View \nSort: Unknown (Descending)",
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := GetTitleForView(tc.viewFlag, tc.sortField, tc.sortOrder)
+			if got != tc.want {
+				t.Fatalf("GetTitleForView(%q, %d, %d) = %q, want %q",
+					tc.viewFlag, tc.sortField, tc.sortOrder, got, tc.want)
+			}
+		})
+	}
+}
+
 func mustMkdirAll(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(path, 0o755); err != nil {


### PR DESCRIPTION
## Summary
- expand config and view helpers tests to exercise edge cases
- add coverage for the templater and markdown parser helpers
- document running `go test ./...` for contributors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d0ac8466108325a990219949f28943