### PR TITLE
Handle note rename/copy without front matter titles

### DIFF
--- a/internal/tui/notes/utils.go
+++ b/internal/tui/notes/utils.go
@@ -116,14 +116,16 @@ func renameFile(m NoteListModel) error {
 			return err
 		}
 
-		title, _ := parseFrontMatter(content, s.path)
-		updatedContent := bytes.Replace(content, []byte(title), []byte(newName), 1)
+		title, _ := parseFrontMatter(content, s.fileName)
+		if title != "" {
+			updatedContent := bytes.Replace(content, []byte(title), []byte(newName), 1)
 
-		if err := os.WriteFile(s.path, updatedContent, 0o644); err != nil {
-			m.list.NewStatusMessage(
-				statusStyle(fmt.Sprintf("Error writing file: %s", err)),
-			)
-			return err
+			if err := os.WriteFile(s.path, updatedContent, 0o644); err != nil {
+				m.list.NewStatusMessage(
+					statusStyle(fmt.Sprintf("Error writing file: %s", err)),
+				)
+				return err
+			}
 		}
 
 		if needsRename {
@@ -162,8 +164,11 @@ func copyFile(m NoteListModel) error {
 			return err
 		}
 
-		title, _ := parseFrontMatter(content, s.path)
-		updatedContent := bytes.Replace(content, []byte(title), []byte(newName), 1)
+		title, _ := parseFrontMatter(content, s.fileName)
+		updatedContent := content
+		if title != "" {
+			updatedContent = bytes.Replace(content, []byte(title), []byte(newName), 1)
+		}
 
 		destFile, err := os.OpenFile(newPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 		if err != nil {

--- a/internal/tui/notes/utils_test.go
+++ b/internal/tui/notes/utils_test.go
@@ -66,6 +66,54 @@ func TestRenameFileSuccess(t *testing.T) {
 	}
 }
 
+func TestRenameFileWithoutTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{
+			name:     "no front matter",
+			contents: "body only",
+		},
+		{
+			name:     "front matter without title",
+			contents: "---\ntags:\n  - tag\n---\nbody",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			originalPath := filepath.Join(dir, "original.md")
+			if err := os.WriteFile(originalPath, []byte(tt.contents), 0o644); err != nil {
+				t.Fatalf("failed to write original file: %v", err)
+			}
+
+			item := ListItem{
+				fileName: "original.md",
+				path:     originalPath,
+			}
+
+			model := newTestNoteListModel(t, item, "Renamed")
+
+			if err := renameFile(model); err != nil {
+				t.Fatalf("renameFile returned error: %v", err)
+			}
+
+			newPath := filepath.Join(dir, "Renamed.md")
+			data, err := os.ReadFile(newPath)
+			if err != nil {
+				t.Fatalf("failed to read renamed file: %v", err)
+			}
+
+			if string(data) != tt.contents {
+				t.Fatalf("expected contents to remain unchanged, got %q", string(data))
+			}
+		})
+	}
+}
+
 func TestRenameFileCollision(t *testing.T) {
 	dir := t.TempDir()
 
@@ -137,6 +185,54 @@ func TestCopyFileSuccess(t *testing.T) {
 
 	if string(data) != "---\ntitle: Copy\n---\nbody" {
 		t.Fatalf("unexpected copied file contents: %q", string(data))
+	}
+}
+
+func TestCopyFileWithoutTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{
+			name:     "no front matter",
+			contents: "body only",
+		},
+		{
+			name:     "front matter without title",
+			contents: "---\ntags:\n  - tag\n---\nbody",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			originalPath := filepath.Join(dir, "original.md")
+			if err := os.WriteFile(originalPath, []byte(tt.contents), 0o644); err != nil {
+				t.Fatalf("failed to write original file: %v", err)
+			}
+
+			item := ListItem{
+				fileName: "original.md",
+				path:     originalPath,
+			}
+
+			model := newTestNoteListModel(t, item, "Copy")
+
+			if err := copyFile(model); err != nil {
+				t.Fatalf("copyFile returned error: %v", err)
+			}
+
+			copyPath := filepath.Join(dir, "Copy.md")
+			data, err := os.ReadFile(copyPath)
+			if err != nil {
+				t.Fatalf("failed to read copied file: %v", err)
+			}
+
+			if string(data) != tt.contents {
+				t.Fatalf("expected contents to remain unchanged, got %q", string(data))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- guard rename and copy operations so front matter titles are only updated when present, using the file name as the fallback
- keep note bodies untouched when no title is found during rename or copy
- add regression tests for renaming and copying notes missing titles

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0b00d27c4832592f39353413f252c