### PR TITLE
Handle blank note titles when sorting and add tests

### DIFF
--- a/internal/tui/notes/sort.go
+++ b/internal/tui/notes/sort.go
@@ -30,10 +30,12 @@ func sortItems(items []ListItem, field sortField, order sortOrder) []list.Item {
 	sort.Slice(sortedItems, func(i, j int) bool {
 		switch field {
 		case sortByTitle:
+			iTitle := titleForSort(sortedItems[i])
+			jTitle := titleForSort(sortedItems[j])
 			if order == ascending {
-				return strings.Compare(sortedItems[i].title, sortedItems[j].title) < 0
+				return strings.Compare(iTitle, jTitle) < 0
 			}
-			return strings.Compare(sortedItems[i].title, sortedItems[j].title) > 0
+			return strings.Compare(iTitle, jTitle) > 0
 		case sortBySubdir:
 			if order == ascending {
 				return strings.Compare(
@@ -70,4 +72,11 @@ func parseDate(dateStr string) time.Time {
 	layout := "Mon, 02 Jan 2006 15:04:05 MST"
 	t, _ := time.Parse(layout, dateStr)
 	return t
+}
+
+func titleForSort(item ListItem) string {
+	if item.title == "" {
+		return strings.TrimSuffix(item.fileName, ".md")
+	}
+	return item.title
 }

--- a/internal/tui/notes/sort_test.go
+++ b/internal/tui/notes/sort_test.go
@@ -1,0 +1,65 @@
+package notes
+
+import "testing"
+
+func TestSortItemsTitleFallsBackToFilename(t *testing.T) {
+	items := []ListItem{
+		{fileName: "beta.md"},
+		{fileName: "alpha.md"},
+		{fileName: "gamma.md", title: "gamma note"},
+	}
+
+	sorted := sortItems(items, sortByTitle, ascending)
+
+	got := make([]ListItem, len(sorted))
+	for i, item := range sorted {
+		listItem, ok := item.(ListItem)
+		if !ok {
+			t.Fatalf("expected ListItem, got %T", item)
+		}
+		got[i] = listItem
+	}
+
+	if got[0].fileName != "alpha.md" {
+		t.Fatalf("expected first item to be alpha.md, got %q", got[0].fileName)
+	}
+
+	if got[1].fileName != "beta.md" {
+		t.Fatalf("expected second item to be beta.md, got %q", got[1].fileName)
+	}
+
+	if got[2].title != "gamma note" {
+		t.Fatalf("expected third item to keep title 'gamma note', got %q", got[2].title)
+	}
+}
+
+func TestSortItemsTitleFallsBackToFilenameDescending(t *testing.T) {
+	items := []ListItem{
+		{fileName: "beta.md"},
+		{fileName: "alpha.md"},
+		{fileName: "gamma.md", title: "gamma note"},
+	}
+
+	sorted := sortItems(items, sortByTitle, descending)
+
+	got := make([]ListItem, len(sorted))
+	for i, item := range sorted {
+		listItem, ok := item.(ListItem)
+		if !ok {
+			t.Fatalf("expected ListItem, got %T", item)
+		}
+		got[i] = listItem
+	}
+
+	if got[0].title != "gamma note" {
+		t.Fatalf("expected first item to have title 'gamma note', got %q", got[0].title)
+	}
+
+	if got[1].fileName != "beta.md" {
+		t.Fatalf("expected second item to be beta.md, got %q", got[1].fileName)
+	}
+
+	if got[2].fileName != "alpha.md" {
+		t.Fatalf("expected third item to be alpha.md, got %q", got[2].fileName)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure note title sorting falls back to the filename when a front matter title is missing
- add unit tests covering ascending and descending title sorting with filename fallbacks

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0b073bbf48325baff9ec47ddf31d4