### PR TITLE
Include unfulfilled view in rotation

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -478,6 +478,8 @@ func (m *NoteListModel) toggleDetails() tea.Cmd {
 func (m *NoteListModel) cycleView() tea.Cmd {
 	switch m.viewName {
 	case "default":
+		m.viewName = "unfulfilled"
+	case "unfulfilled":
 		m.viewName = "archive"
 	case "archive":
 		m.viewName = "orphan"

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -1,0 +1,39 @@
+package notes
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+
+	"github.com/Paintersrp/an/internal/handler"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/internal/views"
+)
+
+func TestCycleViewOrder(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	fileHandler := handler.NewFileHandler(tempDir)
+	viewManager := views.NewViewManager(fileHandler, tempDir)
+
+	delegate := list.NewDefaultDelegate()
+	l := list.New([]list.Item{}, delegate, 0, 0)
+
+	model := &NoteListModel{
+		list:      l,
+		state:     &state.State{Handler: fileHandler, ViewManager: viewManager, Vault: tempDir},
+		viewName:  "default",
+		sortField: sortByTitle,
+		sortOrder: ascending,
+	}
+
+	expectedOrder := []string{"unfulfilled", "archive", "orphan", "trash", "default"}
+
+	for i, want := range expectedOrder {
+		model.cycleView()
+		if got := model.viewName; got != want {
+			t.Fatalf("step %d: expected view %q, got %q", i+1, want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- include the unfulfilled view when cycling note views so the loop visits every configured view
- add a regression test that asserts the cycle order from the default view

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0b06b60ac8325b042cd871807ad23