### PR TITLE
Fix note filter value title fallback

### DIFF
--- a/internal/tui/notes/items.go
+++ b/internal/tui/notes/items.go
@@ -52,13 +52,13 @@ func (i ListItem) Description() string {
 }
 
 func (i ListItem) FilterValue() string {
-	str := strings.Join(i.tags, " ")
-	return fmt.Sprintf(
-		"%s [%s] [%s]",
-		i.title,
-		str,
-		i.subdirectory,
-	)
+        str := strings.Join(i.tags, " ")
+        return fmt.Sprintf(
+                "%s [%s] [%s]",
+                i.Title(),
+                str,
+                i.subdirectory,
+        )
 }
 
 func (i ListItem) Path() string {

--- a/internal/tui/notes/items_test.go
+++ b/internal/tui/notes/items_test.go
@@ -1,0 +1,35 @@
+package notes
+
+import "testing"
+
+func TestListItemFilterValueUsesTitle(t *testing.T) {
+	t.Parallel()
+
+	item := ListItem{
+		title:        "Front Matter Title",
+		tags:         []string{"project", "draft"},
+		subdirectory: "notes",
+	}
+
+	got := item.FilterValue()
+	want := "Front Matter Title [project draft] [notes]"
+
+	if got != want {
+		t.Fatalf("FilterValue() = %q, want %q", got, want)
+	}
+}
+
+func TestListItemFilterValueFallsBackToFilename(t *testing.T) {
+	t.Parallel()
+
+	item := ListItem{
+		fileName: "meeting-notes.md",
+	}
+
+	got := item.FilterValue()
+	want := "meeting-notes [] []"
+
+	if got != want {
+		t.Fatalf("FilterValue() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- use the ListItem Title accessor when building filter values so filenames remain searchable
- add unit tests covering filter values for notes with and without front matter

## Testing
- go test ./internal/tui/notes -run TestListItemFilterValue -count=1 -v

------
https://chatgpt.com/codex/tasks/task_e_68d0b2a120548325afebc1d9e0d237b1