### PR TITLE
Seed copy and rename dialogs with note titles

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -508,7 +508,19 @@ func (m *NoteListModel) toggleCopy() {
 		m.copying = true
 		m.inputModel.Input.Focus()
 		if s, ok := m.list.SelectedItem().(ListItem); ok {
-			m.inputModel.Input.SetValue(s.title + "-copy")
+			base := s.Title()
+			if base == "" {
+				base = strings.TrimSuffix(s.fileName, ".md")
+			}
+			if base == "" {
+				break
+			}
+
+			const suffix = "-copy"
+			if !strings.HasSuffix(base, suffix) {
+				base += suffix
+			}
+			m.inputModel.Input.SetValue(base)
 		}
 	}
 }
@@ -522,7 +534,11 @@ func (m *NoteListModel) toggleRename() {
 		m.renaming = true
 		m.inputModel.Input.Focus()
 		if s, ok := m.list.SelectedItem().(ListItem); ok {
-			m.inputModel.Input.SetValue(s.title)
+			value := s.Title()
+			if value == "" {
+				value = strings.TrimSuffix(s.fileName, ".md")
+			}
+			m.inputModel.Input.SetValue(value)
 		}
 	}
 }

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -37,3 +37,88 @@ func TestCycleViewOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestToggleRenameSeedsInputValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		item ListItem
+		want string
+	}{
+		{
+			name: "with title",
+			item: ListItem{title: "Front Matter Title", fileName: "front-matter-title.md"},
+			want: "Front Matter Title",
+		},
+		{
+			name: "without title",
+			item: ListItem{title: "", fileName: "plain-note.md"},
+			want: "plain-note",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			model := newTestNoteListModel(t, tc.item, "")
+
+			model.toggleRename()
+
+			if !model.renaming {
+				t.Fatalf("expected renaming to be true")
+			}
+
+			if got := model.inputModel.Input.Value(); got != tc.want {
+				t.Fatalf("expected input value %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestToggleCopySeedsInputValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		item ListItem
+		want string
+	}{
+		{
+			name: "with title",
+			item: ListItem{title: "Front Matter Title", fileName: "front-matter-title.md"},
+			want: "Front Matter Title-copy",
+		},
+		{
+			name: "without title",
+			item: ListItem{title: "", fileName: "plain-note.md"},
+			want: "plain-note-copy",
+		},
+		{
+			name: "already suffixed",
+			item: ListItem{title: "Front Matter Title-copy", fileName: "front-matter-title-copy.md"},
+			want: "Front Matter Title-copy",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			model := newTestNoteListModel(t, tc.item, "")
+
+			model.toggleCopy()
+
+			if !model.copying {
+				t.Fatalf("expected copying to be true")
+			}
+
+			if got := model.inputModel.Input.Value(); got != tc.want {
+				t.Fatalf("expected input value %q, got %q", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- seed rename and copy modals with the note title or filename fallback
- avoid duplicating the -copy suffix when preparing copy names
- add tests that cover titled and untitled notes for copy/rename dialogs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0b2b6e5e48325955a9dc85a240164