### PR TITLE
Fix day template tag generation

### DIFF
--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -119,7 +119,7 @@ func (t *Templater) GenerateTagsAndDate(tmplName string) (string, []string) {
 	hour := fmt.Sprintf("%02dh", cur.Hour())
 
 	switch tmplName {
-	case "daily":
+	case "day", "daily":
 		return zetTime, []string{"daily", day, hour}
 	default:
 		return zetTime, []string{}

--- a/internal/templater/templater_test.go
+++ b/internal/templater/templater_test.go
@@ -1,10 +1,12 @@
 package templater
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewTemplaterRegistersUserTemplate(t *testing.T) {
@@ -77,6 +79,40 @@ func TestGenerateTagsAndDateDefaultTemplate(t *testing.T) {
 
 	if len(tags) != 0 {
 		t.Fatalf("expected non-daily template to have zero tags, got %#v", tags)
+	}
+}
+
+func TestGenerateTagsAndDateDayTemplate(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+
+	templater := &Templater{}
+
+	before := time.Now().UTC()
+	date, tags := templater.GenerateTagsAndDate("day")
+	after := time.Now().UTC()
+
+	if len(date) == 0 {
+		t.Fatal("expected generated date to be non-empty")
+	}
+
+	if len(tags) != 3 {
+		t.Fatalf("expected day template to have three tags, got %#v", tags)
+	}
+
+	if tags[0] != "daily" {
+		t.Fatalf("expected first tag to be 'daily', got %q", tags[0])
+	}
+
+	beforeDay := strings.ToLower(before.Weekday().String())
+	afterDay := strings.ToLower(after.Weekday().String())
+	if tags[1] != beforeDay && tags[1] != afterDay {
+		t.Fatalf("expected second tag to match weekday, got %q (expected %q or %q)", tags[1], beforeDay, afterDay)
+	}
+
+	beforeHour := fmt.Sprintf("%02dh", before.Hour())
+	afterHour := fmt.Sprintf("%02dh", after.Hour())
+	if tags[2] != beforeHour && tags[2] != afterHour {
+		t.Fatalf("expected third tag to match hour, got %q (expected %q or %q)", tags[2], beforeHour, afterHour)
 	}
 }
 

--- a/pkg/shared/flags/template.go
+++ b/pkg/shared/flags/template.go
@@ -25,7 +25,7 @@ func AddTemplate(cmd *cobra.Command, def string) {
 			"template",
 			"t",
 			defaultTemplate,
-			"Specify the template to use (default is 'zet'). Available templates: daily, roadmap, zet",
+			"Specify the template to use (default is 'zet'). Available templates: day, roadmap, zet",
 		)
 	viper.BindPFlag(
 		"template",


### PR DESCRIPTION
## Summary
- ensure the day template triggers daily tag generation by accepting the "day" key
- add a unit test that checks the day template emits the weekday and hour tags
- update the template flag help text to advertise the corrected day template name

## Testing
- go test ./internal/templater

------
https://chatgpt.com/codex/tasks/task_e_68d0b8275594832591fa7c7c03c2fc5f