### PR TITLE
Prevent panic when inline content is omitted

### DIFF
--- a/pkg/cmd/new/new.go
+++ b/pkg/cmd/new/new.go
@@ -97,10 +97,8 @@ func run(
 		if err == nil && msg != "" {
 			content = msg
 		}
-	} else {
-		if len(args) < 1 {
-			content = arg.HandleContent(args)
-		}
+	} else if len(args) >= 3 {
+		content = arg.HandleContent(args)
 	}
 
 	var (

--- a/pkg/shared/arg/content.go
+++ b/pkg/shared/arg/content.go
@@ -3,7 +3,7 @@ package arg
 func HandleContent(args []string) string {
 	content := ""
 
-	if len(args) > 1 {
+	if len(args) >= 3 {
 		content = args[2]
 	}
 

--- a/pkg/shared/arg/content_test.go
+++ b/pkg/shared/arg/content_test.go
@@ -1,0 +1,36 @@
+package arg
+
+import "testing"
+
+func TestHandleContent(t *testing.T) {
+	cases := []struct {
+		name   string
+		args   []string
+		expect string
+	}{
+		{
+			name:   "title only",
+			args:   []string{"title"},
+			expect: "",
+		},
+		{
+			name:   "title and tags",
+			args:   []string{"title", "tag1 tag2"},
+			expect: "",
+		},
+		{
+			name:   "title tags content",
+			args:   []string{"title", "tag1 tag2", "content body"},
+			expect: "content body",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := HandleContent(tc.args)
+			if got != tc.expect {
+				t.Fatalf("HandleContent(%v) = %q, want %q", tc.args, got, tc.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- guard `HandleContent` so it only reads the third argument when supplied
- update the new command to propagate inline content when paste mode is disabled
- add unit tests covering title-only, title+tags, and title+tags+content scenarios

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0bc5c16188325973a9182b06e6fb0