### PR TITLE
Normalize vault paths when opening notes

### DIFF
--- a/internal/note/note.go
+++ b/internal/note/note.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/Paintersrp/an/internal/pathutil"
 	"github.com/Paintersrp/an/internal/templater"
 )
 
@@ -244,8 +245,13 @@ func openWithNvim(path string) error {
 // openWithObsidian opens the note in Obsidian.
 func openWithObsidian(path string) error {
 	fullVaultDir := viper.GetString("vaultdir")
-	vaultName := filepath.Base(fullVaultDir)
-	relativePath := strings.TrimPrefix(path, fullVaultDir+"/")
+	normalizedVaultDir := pathutil.NormalizePath(fullVaultDir)
+	vaultName := filepath.Base(normalizedVaultDir)
+
+	relativePath, err := pathutil.VaultRelative(fullVaultDir, path)
+	if err != nil {
+		return fmt.Errorf("unable to determine relative path for obsidian: %w", err)
+	}
 
 	obsidianURI := fmt.Sprintf(
 		"obsidian://open?vault=%s&file=%s",

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,54 @@
+package pathutil
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// NormalizePath converts Windows-style separators to the current platform's separator
+// and cleans the resulting path.
+func NormalizePath(p string) string {
+	if p == "" {
+		return ""
+	}
+
+	// Replace Windows separators and collapse redundant separators/segments.
+	replaced := strings.ReplaceAll(p, "\\", "/")
+	return filepath.Clean(filepath.FromSlash(replaced))
+}
+
+// VaultRelative returns the path to target relative to the provided vault directory.
+// The returned path always uses forward slashes to simplify downstream processing
+// and ensure platform agnosticism.
+func VaultRelative(vaultDir, target string) (string, error) {
+	base := NormalizePath(vaultDir)
+	cleanedTarget := NormalizePath(target)
+
+	rel, err := filepath.Rel(base, cleanedTarget)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.ToSlash(rel), nil
+}
+
+// VaultRelativeComponents splits the relative path from VaultRelative into the first
+// directory (if present) and the remaining path.
+func VaultRelativeComponents(vaultDir, target string) (string, string, error) {
+	rel, err := VaultRelative(vaultDir, target)
+	if err != nil {
+		return "", "", err
+	}
+
+	rel = strings.TrimPrefix(rel, "./")
+	if rel == "." || rel == "" {
+		return "", "", nil
+	}
+
+	parts := strings.Split(rel, "/")
+	if len(parts) == 1 {
+		return "", parts[0], nil
+	}
+
+	return parts[0], strings.Join(parts[1:], "/"), nil
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -1,0 +1,81 @@
+package pathutil
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVaultRelativeReturnsForwardSlashes(t *testing.T) {
+	vaultParts := []string{"home", "user", "vault"}
+	fileParts := append(append([]string{}, vaultParts...), "subdir", "file.md")
+
+	posixVault := filepath.Join(vaultParts...)
+	posixFile := filepath.Join(fileParts...)
+
+	rel, err := VaultRelative(posixVault, posixFile)
+	if err != nil {
+		t.Fatalf("VaultRelative returned error for POSIX paths: %v", err)
+	}
+	if rel != "subdir/file.md" {
+		t.Fatalf("expected relative path 'subdir/file.md', got %q", rel)
+	}
+
+	windowsVault := strings.ReplaceAll(posixVault, string(filepath.Separator), "\\")
+	windowsFile := strings.ReplaceAll(posixFile, string(filepath.Separator), "\\")
+
+	rel, err = VaultRelative(windowsVault, windowsFile)
+	if err != nil {
+		t.Fatalf("VaultRelative returned error for Windows paths: %v", err)
+	}
+	if rel != "subdir/file.md" {
+		t.Fatalf("expected relative path 'subdir/file.md', got %q", rel)
+	}
+}
+
+func TestVaultRelativeComponentsHandlesRootAndNested(t *testing.T) {
+	vault := filepath.Join("vault")
+	rootFile := filepath.Join("vault", "root.md")
+	nestedFile := filepath.Join("vault", "sub", "dir", "note.md")
+
+	subDir, remainder, err := VaultRelativeComponents(vault, rootFile)
+	if err != nil {
+		t.Fatalf("VaultRelativeComponents returned error for root file: %v", err)
+	}
+	if subDir != "" {
+		t.Fatalf("expected empty subdir for root file, got %q", subDir)
+	}
+	if remainder != "root.md" {
+		t.Fatalf("expected remainder 'root.md', got %q", remainder)
+	}
+
+	subDir, remainder, err = VaultRelativeComponents(vault, nestedFile)
+	if err != nil {
+		t.Fatalf("VaultRelativeComponents returned error for nested file: %v", err)
+	}
+	if subDir != "sub" {
+		t.Fatalf("expected first subdirectory 'sub', got %q", subDir)
+	}
+	if remainder != "dir/note.md" {
+		t.Fatalf("expected remainder 'dir/note.md', got %q", remainder)
+	}
+}
+
+func TestVaultRelativeComponentsWithWindowsPaths(t *testing.T) {
+	vault := filepath.Join("vault")
+	nested := filepath.Join("vault", "folder", "child.md")
+
+	windowsVault := strings.ReplaceAll(vault, string(filepath.Separator), "\\")
+	windowsNested := strings.ReplaceAll(nested, string(filepath.Separator), "\\")
+
+	subDir, remainder, err := VaultRelativeComponents(windowsVault, windowsNested)
+	if err != nil {
+		t.Fatalf("VaultRelativeComponents returned error for Windows paths: %v", err)
+	}
+	if subDir != "folder" {
+		t.Fatalf("expected first subdirectory 'folder', got %q", subDir)
+	}
+	if remainder != "child.md" {
+		t.Fatalf("expected remainder 'child.md', got %q", remainder)
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared pathutil helper to normalize vault paths and compute forward-slashed relatives
- update Obsidian launch, fuzzy finder execution, and note list parsing to use the helper and handle root-level notes
- cover relative-path behavior with cross-platform unit tests for the helper and parse logic

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0bc7e0db88325a562ec3e1d61b544