### PR TITLE
Fix WalkFiles depth filter and add tests

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -79,20 +79,12 @@ func (h *FileHandler) WalkFiles(
 	modeFlag string,
 ) ([]string, error) {
 	var files []string
-	baseDepth := len(strings.Split(h.vaultDir, string(os.PathSeparator)))
 
 	err := filepath.Walk(
 		h.vaultDir,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
-			}
-
-			depth := len(strings.Split(path, string(os.PathSeparator)))
-
-			// Skip files that are directly in the vaultDir
-			if depth == baseDepth+1 && !info.IsDir() {
-				return nil
 			}
 
 			dir := filepath.Dir(path)

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestWalkFilesDefaultIncludesRootAndNestedNotes(t *testing.T) {
+	t.Parallel()
+
+	vaultDir := t.TempDir()
+
+	rootNote := filepath.Join(vaultDir, "root.md")
+	nestedDir := filepath.Join(vaultDir, "project")
+	nestedNote := filepath.Join(nestedDir, "nested.md")
+	archivedNote := filepath.Join(vaultDir, "archive", "archived.md")
+	trashedNote := filepath.Join(vaultDir, "trash", "trashed.md")
+
+	mustWriteFile(t, rootNote)
+	mustMkdirAll(t, nestedDir)
+	mustWriteFile(t, nestedNote)
+	mustWriteFile(t, archivedNote)
+	mustWriteFile(t, trashedNote)
+
+	h := NewFileHandler(vaultDir)
+
+	files, err := h.WalkFiles([]string{"archive", "trash"}, nil, "default")
+	if err != nil {
+		t.Fatalf("WalkFiles returned error: %v", err)
+	}
+
+	slices.Sort(files)
+	expected := []string{rootNote, nestedNote}
+	slices.Sort(expected)
+
+	if !slices.Equal(files, expected) {
+		t.Fatalf("WalkFiles returned %v, want %v", files, expected)
+	}
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("failed to create directory %s: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create directory %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("# test\n"), 0o644); err != nil {
+		t.Fatalf("failed to write file %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- remove the WalkFiles depth guard so top-level notes are returned and rely on exclude lists for archive/trash
- add a handler-focused test that builds a fake vault and confirms default view returns root and nested notes

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0c23efc1c8325809ca4d676bb29bd