### PR TITLE
Default template fallback for empty form input

### DIFF
--- a/internal/tui/notes/submodels/form.go
+++ b/internal/tui/notes/submodels/form.go
@@ -40,6 +40,7 @@ var (
 			Padding(1, 0)
 
 	continueStyle = lipgloss.NewStyle().Foreground(darkGray)
+	noteLauncher  = note.StaticHandleNoteLaunch
 )
 
 type FormModel struct {
@@ -257,8 +258,9 @@ func (m FormModel) handleSubmit() FormModel {
 	}
 
 	tmpl := m.Inputs[template].Value()
-
-	if _, ok := templater.AvailableTemplates[tmpl]; !ok {
+	if tmpl == "" {
+		tmpl = "zet"
+	} else if _, ok := templater.AvailableTemplates[tmpl]; !ok {
 		var templateNames []string
 		for name := range templater.AvailableTemplates {
 			templateNames = append(templateNames, name)
@@ -299,7 +301,7 @@ func (m FormModel) handleSubmit() FormModel {
 	}
 
 	// TODO: Content instead of "" ?
-	note.StaticHandleNoteLaunch(n, m.state.Templater, tmpl, "")
+	noteLauncher(n, m.state.Templater, tmpl, "")
 
 	return m
 }

--- a/internal/tui/notes/submodels/form_test.go
+++ b/internal/tui/notes/submodels/form_test.go
@@ -1,0 +1,72 @@
+package submodels
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textinput"
+
+	"github.com/Paintersrp/an/internal/note"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+func TestHandleSubmitUsesDefaultTemplateWhenEmpty(t *testing.T) {
+	tempDir := t.TempDir()
+
+	inputs := make([]textinput.Model, 5)
+	inputs[title] = textinput.New()
+	inputs[title].SetValue("Test Note")
+	inputs[tags] = textinput.New()
+	inputs[links] = textinput.New()
+	inputs[template] = textinput.New()
+	inputs[subdirectory] = textinput.New()
+	inputs[subdirectory].SetValue("notes")
+
+	model := FormModel{
+		state: &state.State{
+			Vault:     tempDir,
+			Templater: &templater.Templater{},
+		},
+		Inputs:           inputs,
+		availableSubdirs: []string{"notes"},
+	}
+
+	var capturedTemplate string
+	originalLauncher := noteLauncher
+	noteLauncher = func(_ *note.ZettelkastenNote, _ *templater.Templater, tmpl, _ string) {
+		capturedTemplate = tmpl
+	}
+	defer func() {
+		noteLauncher = originalLauncher
+	}()
+
+	originalStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	model.handleSubmit()
+
+	_ = w.Close()
+	os.Stdout = originalStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+	_ = r.Close()
+	output := buf.String()
+
+	if capturedTemplate != "zet" {
+		t.Fatalf("expected default template 'zet', got %q", capturedTemplate)
+	}
+
+	if output != "" {
+		t.Fatalf("expected no output, got %q", output)
+	}
+}


### PR DESCRIPTION
## Summary
- default the form template field to "zet" before validating overrides
- allow the note launcher call to be stubbed for testing
- add a regression test that verifies empty templates use the default without emitting an error message

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d12c2083e083259b0872c40bc15722