### PR TITLE
Allow blank subdirectory in TUI note form

### DIFF
--- a/internal/tui/notes/submodels/form.go
+++ b/internal/tui/notes/submodels/form.go
@@ -279,7 +279,7 @@ func (m FormModel) handleSubmit() FormModel {
 
 	subDir := m.Inputs[subdirectory].Value()
 
-	if !m.subdirectoryExists(subDir) {
+	if subDir != "" && !m.subdirectoryExists(subDir) {
 		fmt.Printf("Subdirectory '%s' does not exist.\n", subDir)
 		return m
 	}
@@ -305,6 +305,10 @@ func (m FormModel) handleSubmit() FormModel {
 }
 
 func (m FormModel) subdirectoryExists(subDir string) bool {
+	if subDir == "" {
+		return true
+	}
+
 	for _, dir := range m.availableSubdirs {
 		if dir == subDir {
 			return true

--- a/internal/tui/notes/submodels/form_test.go
+++ b/internal/tui/notes/submodels/form_test.go
@@ -1,0 +1,63 @@
+package submodels
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/Paintersrp/an/internal/handler"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+func TestHandleSubmitCreatesNoteWithBlankSubdirectory(t *testing.T) {
+	tempVault := t.TempDir()
+
+	stubDir := t.TempDir()
+	editorPath := filepath.Join(stubDir, "nvim")
+	if err := os.WriteFile(editorPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("failed to create stub editor: %v", err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", stubDir+string(os.PathListSeparator)+originalPath); err != nil {
+		t.Fatalf("failed to set PATH: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("PATH", originalPath)
+	})
+
+	originalEditor := viper.GetString("editor")
+	originalVault := viper.GetString("vaultdir")
+	viper.Set("editor", "nvim")
+	viper.Set("vaultdir", tempVault)
+	t.Cleanup(func() {
+		viper.Set("editor", originalEditor)
+		viper.Set("vaultdir", originalVault)
+	})
+
+	tmpl, err := templater.NewTemplater()
+	if err != nil {
+		t.Fatalf("failed to create templater: %v", err)
+	}
+
+	testState := &state.State{
+		Vault:     tempVault,
+		Handler:   handler.NewFileHandler(tempVault),
+		Templater: tmpl,
+	}
+
+	form := NewFormModel(testState)
+	form.Inputs[title].SetValue("blank-subdir-note")
+	form.Inputs[template].SetValue("zet")
+	form.Inputs[subdirectory].SetValue("")
+
+	form = form.handleSubmit()
+
+	notePath := filepath.Join(tempVault, "blank-subdir-note.md")
+	if _, err := os.Stat(notePath); err != nil {
+		t.Fatalf("expected note file to be created, but got error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- allow the notes form to treat an empty subdirectory as valid while continuing to validate non-empty inputs
- add a regression test that submits the form with a blank subdirectory and verifies note creation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d12c25f5ec8325bf5246416cc8a5ba