### PR TITLE
Refine journal entry argument parsing

### DIFF
--- a/pkg/cmd/journal/entry/entry.go
+++ b/pkg/cmd/journal/entry/entry.go
@@ -13,10 +13,11 @@ import (
 	"github.com/Paintersrp/an/internal/note"
 	"github.com/Paintersrp/an/internal/state"
 	"github.com/Paintersrp/an/internal/templater"
-	"github.com/Paintersrp/an/pkg/shared/arg"
 	"github.com/Paintersrp/an/pkg/shared/flags"
 	"github.com/Paintersrp/an/utils"
 )
+
+var readClipboard = clipboard.ReadAll
 
 // TODO: adding links/tags/content after note already exists?
 
@@ -78,7 +79,12 @@ func run(
 	index int,
 	templateType string,
 ) error {
-	tags, err := utils.ValidateInput(strings.Join(args, " "))
+	tagInput := ""
+	if len(args) > 0 {
+		tagInput = args[0]
+	}
+
+	tags, err := utils.ValidateInput(tagInput)
 	if err != nil {
 		fmt.Printf("error processing tags argument: %s", err)
 		os.Exit(1)
@@ -92,12 +98,14 @@ func run(
 	}
 
 	if paste {
-		msg, err := clipboard.ReadAll()
+		msg, err := readClipboard()
 		if err == nil && msg != "" {
 			content = msg
 		}
 	} else {
-		content = arg.HandleContent(args)
+		if len(args) >= 2 {
+			content = args[1]
+		}
 	}
 
 	links := flags.HandleLinks(cmd)

--- a/pkg/cmd/journal/entry/entry_test.go
+++ b/pkg/cmd/journal/entry/entry_test.go
@@ -1,0 +1,129 @@
+package entry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/internal/templater"
+	"github.com/Paintersrp/an/utils"
+)
+
+func setupEntryTest(t *testing.T) (*state.State, string) {
+	t.Helper()
+
+	t.Setenv("HOME", t.TempDir())
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	vaultDir := t.TempDir()
+	viper.Set("vaultdir", vaultDir)
+	viper.Set("editor", "nvim")
+	viper.Set("nvimargs", "")
+
+	binDir := t.TempDir()
+	nvimPath := filepath.Join(binDir, "nvim")
+	if err := os.WriteFile(nvimPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("failed to create nvim stub: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	tmpl, err := templater.NewTemplater()
+	if err != nil {
+		t.Fatalf("failed to create templater: %v", err)
+	}
+
+	st := &state.State{
+		Templater: tmpl,
+	}
+
+	return st, vaultDir
+}
+
+func TestRunWithTagsOnly(t *testing.T) {
+	st, vaultDir := setupEntryTest(t)
+
+	cmd := NewCmdEntry(st, "day")
+	args := []string{"test-tag"}
+
+	if err := run(cmd, args, st.Templater, 0, "day"); err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	date := utils.GenerateDate(0, "day")
+	notePath := filepath.Join(vaultDir, "atoms", fmt.Sprintf("day-%s.md", date))
+
+	content, err := os.ReadFile(notePath)
+	if err != nil {
+		t.Fatalf("failed to read note: %v", err)
+	}
+
+	if !strings.Contains(string(content), "- test-tag") {
+		t.Fatalf("expected note to contain tag, content: %s", string(content))
+	}
+}
+
+func TestRunWithTagsAndInlineContent(t *testing.T) {
+	st, vaultDir := setupEntryTest(t)
+
+	cmd := NewCmdEntry(st, "day")
+	args := []string{"inline-tag", "Inline content! #1"}
+
+	if err := run(cmd, args, st.Templater, 0, "day"); err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	date := utils.GenerateDate(0, "day")
+	notePath := filepath.Join(vaultDir, "atoms", fmt.Sprintf("day-%s.md", date))
+
+	content, err := os.ReadFile(notePath)
+	if err != nil {
+		t.Fatalf("failed to read note: %v", err)
+	}
+
+	if !strings.Contains(string(content), "Inline content! #1") {
+		t.Fatalf("expected note to contain inline content, content: %s", string(content))
+	}
+}
+
+func TestRunWithPasteContent(t *testing.T) {
+	st, vaultDir := setupEntryTest(t)
+
+	cmd := NewCmdEntry(st, "day")
+	if err := cmd.Flags().Set("paste", "true"); err != nil {
+		t.Fatalf("failed to set paste flag: %v", err)
+	}
+
+	originalReadClipboard := readClipboard
+	readClipboard = func() (string, error) {
+		return "Pasted content!", nil
+	}
+	t.Cleanup(func() {
+		readClipboard = originalReadClipboard
+	})
+
+	args := []string{"paste-tag"}
+
+	if err := run(cmd, args, st.Templater, 0, "day"); err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	date := utils.GenerateDate(0, "day")
+	notePath := filepath.Join(vaultDir, "atoms", fmt.Sprintf("day-%s.md", date))
+
+	content, err := os.ReadFile(notePath)
+	if err != nil {
+		t.Fatalf("failed to read note: %v", err)
+	}
+
+	if !strings.Contains(string(content), "Pasted content!") {
+		t.Fatalf("expected note to contain pasted content, content: %s", string(content))
+	}
+}


### PR DESCRIPTION
## Summary
- update the journal entry command to treat the first argument as tags, accept the second as raw inline content, and reuse clipboard reads through an overridable helper
- add end-to-end command tests covering tag-only, inline content, and paste scenarios to verify note creation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d12c26b28083258469bb4c30656e0c