### PR TITLE
Fix InputModel update recursion

### DIFF
--- a/internal/tui/notes/submodels/input.go
+++ b/internal/tui/notes/submodels/input.go
@@ -59,7 +59,8 @@ func (m InputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	_, cmd := m.Update(msg)
+	var cmd tea.Cmd
+	m.Input, cmd = m.Input.Update(msg)
 
 	return m, cmd
 }

--- a/internal/tui/notes/submodels/input_test.go
+++ b/internal/tui/notes/submodels/input_test.go
@@ -1,0 +1,32 @@
+package submodels
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/cursor"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestInputModelUpdateHandlesKeyMessages(t *testing.T) {
+	m := NewInputModel()
+
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	updated, ok := model.(InputModel)
+	if !ok {
+		t.Fatalf("expected InputModel, got %T", model)
+	}
+
+	if updated.cursorMode != cursor.CursorStatic {
+		t.Fatalf("expected cursor mode %v, got %v", cursor.CursorStatic, updated.cursorMode)
+	}
+
+	nextModel, _ := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	next, ok := nextModel.(InputModel)
+	if !ok {
+		t.Fatalf("expected InputModel, got %T", nextModel)
+	}
+
+	if next.Input.Value() != "a" {
+		t.Fatalf("expected input value %q, got %q", "a", next.Input.Value())
+	}
+}


### PR DESCRIPTION
## Summary
- forward InputModel updates to the wrapped text input model instead of recursing
- add a regression test to ensure key messages toggle the cursor and update input text

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d12c2852848325b80eb605fb27fb99