### PR TITLE
Default to zet template when form input blank

### DIFF
--- a/internal/tui/notes/submodels/form.go
+++ b/internal/tui/notes/submodels/form.go
@@ -32,6 +32,8 @@ const (
 	darkGray = lipgloss.Color("#767676")
 )
 
+const defaultTemplate = "zet"
+
 var (
 	formInputStyle = lipgloss.NewStyle().Foreground(hotPink)
 	formTitleStyle = lipgloss.NewStyle().
@@ -257,10 +259,12 @@ func (m FormModel) handleSubmit() FormModel {
 		return m
 	}
 
-	tmpl := m.Inputs[template].Value()
+	tmpl := strings.TrimSpace(m.Inputs[template].Value())
 	if tmpl == "" {
-		tmpl = "zet"
-	} else if _, ok := templater.AvailableTemplates[tmpl]; !ok {
+		tmpl = defaultTemplate
+	}
+
+	if _, ok := templater.AvailableTemplates[tmpl]; !ok {
 		var templateNames []string
 		for name := range templater.AvailableTemplates {
 			templateNames = append(templateNames, name)

--- a/internal/tui/notes/submodels/form_test.go
+++ b/internal/tui/notes/submodels/form_test.go
@@ -22,6 +22,7 @@ func TestHandleSubmitUsesDefaultTemplateWhenEmpty(t *testing.T) {
 	inputs[tags] = textinput.New()
 	inputs[links] = textinput.New()
 	inputs[template] = textinput.New()
+	inputs[template].SetValue("   ")
 	inputs[subdirectory] = textinput.New()
 	inputs[subdirectory].SetValue("notes")
 
@@ -36,7 +37,7 @@ func TestHandleSubmitUsesDefaultTemplateWhenEmpty(t *testing.T) {
 
 	var capturedTemplate string
 	originalLauncher := noteLauncher
-	noteLauncher = func(_ *note.ZettelkastenNote, _ *templater.Templater, tmpl, _ string) {
+	noteLauncher = func(_ *note.ZettelkastenNote, _ *templater.Templater, tmpl string, _ string) {
 		capturedTemplate = tmpl
 	}
 	defer func() {
@@ -62,8 +63,8 @@ func TestHandleSubmitUsesDefaultTemplateWhenEmpty(t *testing.T) {
 	_ = r.Close()
 	output := buf.String()
 
-	if capturedTemplate != "zet" {
-		t.Fatalf("expected default template 'zet', got %q", capturedTemplate)
+	if capturedTemplate != defaultTemplate {
+		t.Fatalf("expected default template %q, got %q", defaultTemplate, capturedTemplate)
 	}
 
 	if output != "" {


### PR DESCRIPTION
## Summary
- trim the template field and default it to the zet template before validating available templates
- extend the form submission test to cover whitespace input and assert the default template without emitting errors

## Testing
- go test ./internal/tui/notes/submodels -run TestHandleSubmitUsesDefaultTemplateWhenEmpty -v

------
https://chatgpt.com/codex/tasks/task_e_68d1b7e9c99c8325b6e0b1deae38940a