### PR TITLE
Allow empty subdirectory in note form

### DIFF
--- a/internal/tui/notes/submodels/form.go
+++ b/internal/tui/notes/submodels/form.go
@@ -283,7 +283,7 @@ func (m FormModel) handleSubmit() FormModel {
 		return m
 	}
 
-	subDir := m.Inputs[subdirectory].Value()
+	subDir := strings.TrimSpace(m.Inputs[subdirectory].Value())
 
 	if !m.subdirectoryExists(subDir) {
 		fmt.Printf("Subdirectory '%s' does not exist.\n", subDir)
@@ -311,6 +311,10 @@ func (m FormModel) handleSubmit() FormModel {
 }
 
 func (m FormModel) subdirectoryExists(subDir string) bool {
+	if strings.TrimSpace(subDir) == "" {
+		return true
+	}
+
 	for _, dir := range m.availableSubdirs {
 		if dir == subDir {
 			return true

--- a/internal/tui/notes/submodels/form_test.go
+++ b/internal/tui/notes/submodels/form_test.go
@@ -71,3 +71,65 @@ func TestHandleSubmitUsesDefaultTemplateWhenEmpty(t *testing.T) {
 		t.Fatalf("expected no output, got %q", output)
 	}
 }
+
+func TestHandleSubmitAllowsEmptySubdirectory(t *testing.T) {
+	tempDir := t.TempDir()
+
+	inputs := make([]textinput.Model, 5)
+	inputs[title] = textinput.New()
+	inputs[title].SetValue("Test Note")
+	inputs[tags] = textinput.New()
+	inputs[links] = textinput.New()
+	inputs[template] = textinput.New()
+	inputs[subdirectory] = textinput.New()
+	inputs[subdirectory].SetValue("")
+
+	model := FormModel{
+		state: &state.State{
+			Vault:     tempDir,
+			Templater: &templater.Templater{},
+		},
+		Inputs:           inputs,
+		availableSubdirs: []string{"notes"},
+	}
+
+	var capturedNote *note.ZettelkastenNote
+	originalLauncher := noteLauncher
+	noteLauncher = func(n *note.ZettelkastenNote, _ *templater.Templater, _ string, _ string) {
+		capturedNote = n
+	}
+	defer func() {
+		noteLauncher = originalLauncher
+	}()
+
+	originalStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	model.handleSubmit()
+
+	_ = w.Close()
+	os.Stdout = originalStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+	_ = r.Close()
+	output := buf.String()
+
+	if output != "" {
+		t.Fatalf("expected no output, got %q", output)
+	}
+
+	if capturedNote == nil {
+		t.Fatalf("expected note to be created, but noteLauncher was not called")
+	}
+
+	if capturedNote.SubDir != "" {
+		t.Fatalf("expected empty subdirectory, got %q", capturedNote.SubDir)
+	}
+}


### PR DESCRIPTION
## Summary
- allow blank subdirectory values to bypass the availability check while still validating non-empty entries
- trim the submitted subdirectory before creating notes
- add a regression test that ensures blank subdirectory submissions succeed without errors

## Testing
- go test ./internal/tui/notes/submodels


------
https://chatgpt.com/codex/tasks/task_e_68d1d08a9c5c832589405ebcbae92979