### PR TITLE
Handle inline journal content separately from tags

### DIFF
--- a/pkg/cmd/journal/entry/entry.go
+++ b/pkg/cmd/journal/entry/entry.go
@@ -79,7 +79,7 @@ func run(
 	index int,
 	templateType string,
 ) error {
-	tagInput := ""
+	var tagInput string
 	if len(args) > 0 {
 		tagInput = args[0]
 	}
@@ -91,7 +91,12 @@ func run(
 		return err
 	}
 
-	content := ""
+	var inlineContent string
+	if len(args) > 1 {
+		inlineContent = args[1]
+	}
+
+	content := inlineContent
 	paste, err := flags.HandlePaste(cmd)
 	if err != nil {
 		return err
@@ -101,10 +106,6 @@ func run(
 		msg, err := readClipboard()
 		if err == nil && msg != "" {
 			content = msg
-		}
-	} else {
-		if len(args) >= 2 {
-			content = args[1]
 		}
 	}
 

--- a/pkg/cmd/journal/entry/entry_test.go
+++ b/pkg/cmd/journal/entry/entry_test.go
@@ -88,8 +88,14 @@ func TestRunWithTagsAndInlineContent(t *testing.T) {
 		t.Fatalf("failed to read note: %v", err)
 	}
 
-	if !strings.Contains(string(content), "Inline content! #1") {
+	raw := string(content)
+	if !strings.Contains(raw, "Inline content! #1") {
 		t.Fatalf("expected note to contain inline content, content: %s", string(content))
+	}
+
+	frontMatter := strings.SplitN(raw, "---", 2)[0]
+	if strings.Contains(frontMatter, "Inline content! #1") {
+		t.Fatalf("inline content should not appear in front matter, content: %s", frontMatter)
 	}
 }
 
@@ -123,7 +129,13 @@ func TestRunWithPasteContent(t *testing.T) {
 		t.Fatalf("failed to read note: %v", err)
 	}
 
-	if !strings.Contains(string(content), "Pasted content!") {
+	raw := string(content)
+	if !strings.Contains(raw, "Pasted content!") {
 		t.Fatalf("expected note to contain pasted content, content: %s", string(content))
+	}
+
+	frontMatter := strings.SplitN(raw, "---", 2)[0]
+	if strings.Contains(frontMatter, "Pasted content!") {
+		t.Fatalf("pasted content should not appear in front matter, content: %s", frontMatter)
 	}
 }


### PR DESCRIPTION
## Summary
- treat the first CLI argument as the tag payload and keep inline content separate
- reuse tag validation only for tags and allow raw inline or pasted content to pass through
- expand journal entry command tests to ensure inline and pasted content are persisted outside of front matter

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1d1a2655483259168c1d5ae9a2426