### PR TITLE
Handle non-string cache entries safely

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -138,9 +138,28 @@ func (c *Cache) SizeOf() int64 {
 // sizeof returns the approximate size of the Entry object in bytes.
 func sizeof(e *Entry) int {
 	size := int(unsafe.Sizeof(*e))
-	size += len(e.Key.(string))
-	size += len(e.Value.(string))
+	size += approxSize(e.Key)
+	size += approxSize(e.Value)
 	return size
+}
+
+func approxSize(v interface{}) int {
+	if v == nil {
+		return 0
+	}
+
+	switch val := v.(type) {
+	case string:
+		return len(val)
+	case []byte:
+		return len(val)
+	case fmt.Stringer:
+		return len(val.String())
+	case error:
+		return len(val.Error())
+	default:
+		return len(fmt.Sprint(val))
+	}
 }
 
 type ByteSize float64

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -43,5 +44,56 @@ func TestPutUpdatesExistingEntryWithoutGrowingSize(t *testing.T) {
 
 	if value, hit, err := cache.Get(key2); err != nil || !hit || value != "value" {
 		t.Fatalf("expected key2 to remain in cache, hit=%v err=%v value=%v", hit, err, value)
+	}
+}
+
+func TestPutHandlesNonStringKeyAndValue(t *testing.T) {
+	cache, err := New(1)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
+
+	key := 123
+	value := []byte{1, 2, 3, 4, 5}
+
+	if err := cache.Put(key, value); err != nil {
+		t.Fatalf("put non-string key/value failed: %v", err)
+	}
+
+	expectedSize := sizeof(&Entry{Key: key, Value: value})
+	if cache.SizeOf() != int64(expectedSize) {
+		t.Fatalf("unexpected cache size: got %d, want %d", cache.SizeOf(), expectedSize)
+	}
+}
+
+type customKey struct {
+	name string
+}
+
+func TestEvictionWithNonStringKeyAndValue(t *testing.T) {
+	cache, err := New(1)
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
+
+	key1 := customKey{name: "first"}
+	value1 := bytes.Repeat([]byte("a"), 700*1024)
+	if err := cache.Put(key1, value1); err != nil {
+		t.Fatalf("put key1 failed: %v", err)
+	}
+
+	key2 := customKey{name: "second"}
+	value2 := bytes.Repeat([]byte("b"), 700*1024)
+	if err := cache.Put(key2, value2); err != nil {
+		t.Fatalf("put key2 failed: %v", err)
+	}
+
+	if _, hit, err := cache.Get(key1); err != nil || hit {
+		t.Fatalf("expected key1 to be evicted, hit=%v err=%v", hit, err)
+	}
+
+	expectedSize := sizeof(&Entry{Key: key2, Value: value2})
+	if cache.SizeOf() != int64(expectedSize) {
+		t.Fatalf("unexpected cache size after eviction: got %d, want %d", cache.SizeOf(), expectedSize)
 	}
 }


### PR DESCRIPTION
## Summary
- allow the cache size accounting to handle non-string keys and values
- fall back to fmt.Sprint-based estimates for unknown types and support []byte directly
- add regression tests that insert and evict entries with non-string data to ensure safe sizing

## Testing
- go test ./internal/cache


------
https://chatgpt.com/codex/tasks/task_e_68d1d4f72d508325b0ee8cf47a1dba97