### PR TITLE
Add vault path resolver for archive and trash commands

### DIFF
--- a/pkg/cmd/archive/archive.go
+++ b/pkg/cmd/archive/archive.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/Paintersrp/an/internal/state"
+	cmdpkg "github.com/Paintersrp/an/pkg/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +25,10 @@ func NewCmdArchive(s *state.State) *cobra.Command {
 				fmt.Println("Please provide the path to the note you want to archive.")
 				return nil
 			}
-			path := args[0]
+			path, err := cmdpkg.ResolveVaultPath(cmd, s, args[0])
+			if err != nil {
+				return err
+			}
 			return s.Handler.Archive(path)
 		},
 	}

--- a/pkg/cmd/path_resolver.go
+++ b/pkg/cmd/path_resolver.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func ResolveVaultPath(cmd *cobra.Command, s *state.State, arg string) (string, error) {
+	if s == nil || s.Config == nil {
+		return "", fmt.Errorf("state configuration is not initialized")
+	}
+	vaultDir := filepath.Clean(s.Config.VaultDir)
+	if vaultDir == "" {
+		return "", fmt.Errorf("vault directory is not configured")
+	}
+	if arg == "" {
+		return "", fmt.Errorf("a path argument is required")
+	}
+
+	var resolved string
+	if filepath.IsAbs(arg) {
+		resolved = filepath.Clean(arg)
+	} else {
+		resolved = resolveRelative(cmd, vaultDir, arg)
+	}
+
+	if err := ensureWithinVault(vaultDir, resolved); err != nil {
+		return "", err
+	}
+
+	return resolved, nil
+}
+
+func resolveRelative(cmd *cobra.Command, vaultDir, arg string) string {
+	relPath := filepath.Clean(arg)
+	if relPath == "." {
+		relPath = ""
+	}
+
+	targetDir := inferTargetDir(cmd)
+	if targetDir == "" {
+		if relPath == "" {
+			return vaultDir
+		}
+		return filepath.Join(vaultDir, relPath)
+	}
+
+	firstSegment := relPath
+	if idx := strings.Index(relPath, string(filepath.Separator)); idx != -1 {
+		firstSegment = relPath[:idx]
+	}
+
+	if firstSegment == targetDir {
+		return filepath.Join(vaultDir, relPath)
+	}
+
+	return filepath.Join(vaultDir, targetDir, relPath)
+}
+
+func inferTargetDir(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+
+	switch cmd.Name() {
+	case "unarchive":
+		return "archive"
+	case "untrash":
+		return "trash"
+	default:
+		return ""
+	}
+}
+
+func ensureWithinVault(vaultDir, resolved string) error {
+	rel, err := filepath.Rel(vaultDir, resolved)
+	if err != nil {
+		return fmt.Errorf("failed to resolve path %q relative to vault %q: %w", resolved, vaultDir, err)
+	}
+
+	if rel == "." {
+		return nil
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q is outside the vault %q", resolved, vaultDir)
+	}
+
+	return nil
+}

--- a/pkg/cmd/path_resolver_test.go
+++ b/pkg/cmd/path_resolver_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func TestResolveVaultPath(t *testing.T) {
+	vaultDir := t.TempDir()
+
+	st := &state.State{Config: &config.Config{VaultDir: vaultDir}}
+
+	tests := map[string]struct {
+		command *cobra.Command
+		input   string
+		want    string
+		wantErr bool
+	}{
+		"absolute inside vault": {
+			command: &cobra.Command{Use: "archive"},
+			input:   filepath.Join(vaultDir, "note.md"),
+			want:    filepath.Join(vaultDir, "note.md"),
+		},
+		"relative inside vault": {
+			command: &cobra.Command{Use: "archive"},
+			input:   "note.md",
+			want:    filepath.Join(vaultDir, "note.md"),
+		},
+		"escape attempt": {
+			command: &cobra.Command{Use: "archive"},
+			input:   "../evil.md",
+			wantErr: true,
+		},
+		"unarchive infers archive directory": {
+			command: &cobra.Command{Use: "unarchive"},
+			input:   "restored.md",
+			want:    filepath.Join(vaultDir, "archive", "restored.md"),
+		},
+		"unarchive respects explicit archive prefix": {
+			command: &cobra.Command{Use: "unarchive"},
+			input:   filepath.Join("archive", "restored.md"),
+			want:    filepath.Join(vaultDir, "archive", "restored.md"),
+		},
+		"untrash infers trash directory": {
+			command: &cobra.Command{Use: "untrash"},
+			input:   "restored.md",
+			want:    filepath.Join(vaultDir, "trash", "restored.md"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ResolveVaultPath(tc.command, st, tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveVaultPath returned error: %v", err)
+			}
+			if got != filepath.Clean(tc.want) {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/cmd/trash/trash.go
+++ b/pkg/cmd/trash/trash.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/Paintersrp/an/internal/state"
+	cmdpkg "github.com/Paintersrp/an/pkg/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +27,10 @@ func NewCmdTrash(s *state.State) *cobra.Command {
 				)
 				return nil
 			}
-			path := args[0]
+			path, err := cmdpkg.ResolveVaultPath(cmd, s, args[0])
+			if err != nil {
+				return err
+			}
 			return s.Handler.Trash(path)
 		},
 	}

--- a/pkg/cmd/unarchive/unarchive.go
+++ b/pkg/cmd/unarchive/unarchive.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/Paintersrp/an/internal/state"
+	cmdpkg "github.com/Paintersrp/an/pkg/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +27,10 @@ func NewCmdUnarchive(s *state.State) *cobra.Command {
 				)
 				return nil
 			}
-			path := args[0]
+			path, err := cmdpkg.ResolveVaultPath(cmd, s, args[0])
+			if err != nil {
+				return err
+			}
 			return s.Handler.Unarchive(path)
 		},
 	}

--- a/pkg/cmd/untrash/untrash.go
+++ b/pkg/cmd/untrash/untrash.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Paintersrp/an/internal/state"
+	cmdpkg "github.com/Paintersrp/an/pkg/cmd"
 )
 
 func NewCmdUntrash(s *state.State) *cobra.Command {
@@ -27,7 +28,10 @@ func NewCmdUntrash(s *state.State) *cobra.Command {
 				)
 				return nil
 			}
-			path := args[0]
+			path, err := cmdpkg.ResolveVaultPath(cmd, s, args[0])
+			if err != nil {
+				return err
+			}
 			return s.Handler.Untrash(path)
 		},
 	}


### PR DESCRIPTION
## Summary
- add a shared vault path resolver that normalizes user input and keeps resolutions inside the configured vault
- call the resolver from archive/trash/unarchive/untrash so scripts can pass vault-relative identifiers and inferred archive/trash paths
- add resolver unit tests covering absolute, relative, and escaping inputs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1d556e96c8325ab66f359aa16f6c9