### PR TITLE
Handle missing path arguments with errors

### DIFF
--- a/pkg/cmd/archive/archive.go
+++ b/pkg/cmd/archive/archive.go
@@ -22,8 +22,8 @@ func NewCmdArchive(s *state.State) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				fmt.Println("Please provide the path to the note you want to archive.")
-				return nil
+				_ = cmd.Help()
+				return fmt.Errorf("path argument is required")
 			}
 			path, err := cmdpkg.ResolveVaultPath(cmd, s, args[0])
 			if err != nil {

--- a/pkg/cmd/archive/archive_test.go
+++ b/pkg/cmd/archive/archive_test.go
@@ -1,0 +1,21 @@
+package archive
+
+import (
+	"io"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/state"
+)
+
+func TestArchiveCommandRequiresArgument(t *testing.T) {
+	s := &state.State{}
+	cmd := NewCmdArchive(s)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SilenceUsage = true
+
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected an error when no path argument is provided")
+	}
+}

--- a/pkg/cmd/trash/trash.go
+++ b/pkg/cmd/trash/trash.go
@@ -22,10 +22,8 @@ func NewCmdTrash(s *state.State) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				fmt.Println(
-					"Please provide the path to the note you want to move to the trash.",
-				)
-				return nil
+				_ = cmd.Help()
+				return fmt.Errorf("path argument is required")
 			}
 			path, err := cmdpkg.ResolveVaultPath(cmd, s, args[0])
 			if err != nil {

--- a/pkg/cmd/trash/trash_test.go
+++ b/pkg/cmd/trash/trash_test.go
@@ -1,0 +1,21 @@
+package trash
+
+import (
+	"io"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/state"
+)
+
+func TestTrashCommandRequiresArgument(t *testing.T) {
+	s := &state.State{}
+	cmd := NewCmdTrash(s)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SilenceUsage = true
+
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected an error when no path argument is provided")
+	}
+}

--- a/pkg/cmd/unarchive/unarchive.go
+++ b/pkg/cmd/unarchive/unarchive.go
@@ -22,10 +22,8 @@ func NewCmdUnarchive(s *state.State) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				fmt.Println(
-					"Please provide the path to the archived note you want to unarchive.",
-				)
-				return nil
+				_ = cmd.Help()
+				return fmt.Errorf("path argument is required")
 			}
 			path, err := cmdpkg.ResolveVaultPath(cmd, s, args[0])
 			if err != nil {

--- a/pkg/cmd/unarchive/unarchive_test.go
+++ b/pkg/cmd/unarchive/unarchive_test.go
@@ -1,0 +1,21 @@
+package unarchive
+
+import (
+	"io"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/state"
+)
+
+func TestUnarchiveCommandRequiresArgument(t *testing.T) {
+	s := &state.State{}
+	cmd := NewCmdUnarchive(s)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SilenceUsage = true
+
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected an error when no path argument is provided")
+	}
+}

--- a/pkg/cmd/untrash/untrash.go
+++ b/pkg/cmd/untrash/untrash.go
@@ -23,10 +23,8 @@ func NewCmdUntrash(s *state.State) *cobra.Command {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				fmt.Println(
-					"Please provide the path to the trashed note you want to restore.",
-				)
-				return nil
+				_ = cmd.Help()
+				return fmt.Errorf("path argument is required")
 			}
 			path, err := cmdpkg.ResolveVaultPath(cmd, s, args[0])
 			if err != nil {

--- a/pkg/cmd/untrash/untrash_test.go
+++ b/pkg/cmd/untrash/untrash_test.go
@@ -1,0 +1,21 @@
+package untrash
+
+import (
+	"io"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/state"
+)
+
+func TestUntrashCommandRequiresArgument(t *testing.T) {
+	s := &state.State{}
+	cmd := NewCmdUntrash(s)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SilenceUsage = true
+
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected an error when no path argument is provided")
+	}
+}


### PR DESCRIPTION
## Summary
- return errors from the archive, unarchive, trash, and untrash commands when the required path argument is omitted
- add command unit tests that assert missing path arguments surface an execution error so scripts can detect failures

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1d6e1c1dc8325b946e350d3b91378