### PR TITLE
Ensure path commands error on missing args

### DIFF
--- a/pkg/cmd/archive/archive_test.go
+++ b/pkg/cmd/archive/archive_test.go
@@ -15,7 +15,12 @@ func TestArchiveCommandRequiresArgument(t *testing.T) {
 	cmd.SilenceUsage = true
 
 	cmd.SetArgs([]string{})
-	if err := cmd.Execute(); err == nil {
+	err := cmd.Execute()
+	if err == nil {
 		t.Fatalf("expected an error when no path argument is provided")
+	}
+
+	if err.Error() != "path argument is required" {
+		t.Fatalf("expected error message %q, got %q", "path argument is required", err.Error())
 	}
 }

--- a/pkg/cmd/trash/trash_test.go
+++ b/pkg/cmd/trash/trash_test.go
@@ -15,7 +15,12 @@ func TestTrashCommandRequiresArgument(t *testing.T) {
 	cmd.SilenceUsage = true
 
 	cmd.SetArgs([]string{})
-	if err := cmd.Execute(); err == nil {
+	err := cmd.Execute()
+	if err == nil {
 		t.Fatalf("expected an error when no path argument is provided")
+	}
+
+	if err.Error() != "path argument is required" {
+		t.Fatalf("expected error message %q, got %q", "path argument is required", err.Error())
 	}
 }

--- a/pkg/cmd/unarchive/unarchive_test.go
+++ b/pkg/cmd/unarchive/unarchive_test.go
@@ -15,7 +15,12 @@ func TestUnarchiveCommandRequiresArgument(t *testing.T) {
 	cmd.SilenceUsage = true
 
 	cmd.SetArgs([]string{})
-	if err := cmd.Execute(); err == nil {
+	err := cmd.Execute()
+	if err == nil {
 		t.Fatalf("expected an error when no path argument is provided")
+	}
+
+	if err.Error() != "path argument is required" {
+		t.Fatalf("expected error message %q, got %q", "path argument is required", err.Error())
 	}
 }

--- a/pkg/cmd/untrash/untrash_test.go
+++ b/pkg/cmd/untrash/untrash_test.go
@@ -15,7 +15,12 @@ func TestUntrashCommandRequiresArgument(t *testing.T) {
 	cmd.SilenceUsage = true
 
 	cmd.SetArgs([]string{})
-	if err := cmd.Execute(); err == nil {
+	err := cmd.Execute()
+	if err == nil {
 		t.Fatalf("expected an error when no path argument is provided")
+	}
+
+	if err.Error() != "path argument is required" {
+		t.Fatalf("expected error message %q, got %q", "path argument is required", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- extend archive, trash, unarchive, and untrash command tests to assert missing path errors propagate

## Testing
- go test ./pkg/cmd/...


------
https://chatgpt.com/codex/tasks/task_e_68d1d80b6cd88325a3cb0e6d984f1961