### PR TITLE
Propagate ChangePin errors in pin add command

### DIFF
--- a/pkg/cmd/pin/pinAdd/pinAdd.go
+++ b/pkg/cmd/pin/pinAdd/pinAdd.go
@@ -69,20 +69,26 @@ func run(
 				fmt.Printf("error fuzzyfinding note: %s", err)
 			}
 
-			s.Config.ChangePin(choice, pinType, name)
+			if err := s.Config.ChangePin(choice, pinType, name); err != nil {
+				return err
+			}
 		} else {
 			choice, err := finder.RunWithQuery(args[0], false)
 			if err != nil {
 				fmt.Printf("error fuzzyfinding note: %s", err)
 			}
 
-			s.Config.ChangePin(choice, pinType, name)
+			if err := s.Config.ChangePin(choice, pinType, name); err != nil {
+				return err
+			}
 		}
 	} else {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			return errors.New("the specified file does not exist")
 		}
-		s.Config.ChangePin(path, pinType, name)
+		if err := s.Config.ChangePin(path, pinType, name); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cmd/pin/pinAdd/pinAdd_test.go
+++ b/pkg/cmd/pin/pinAdd/pinAdd_test.go
@@ -1,0 +1,52 @@
+package pinAdd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/pin"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/pkg/shared/flags"
+)
+
+func TestRunReturnsChangePinError(t *testing.T) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "note.md")
+	if err := os.WriteFile(tempFile, []byte("example"), 0o644); err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	cfg := &config.Config{
+		PinManager: pin.NewPinManager(
+			make(pin.PinMap),
+			make(pin.PinMap),
+			"",
+			"",
+		),
+	}
+
+	st := &state.State{Config: cfg}
+
+	cmd := &cobra.Command{}
+	flags.AddPath(cmd)
+	flags.AddName(cmd, "")
+	if err := cmd.Flags().Set("path", tempFile); err != nil {
+		t.Fatalf("failed to set path flag: %v", err)
+	}
+
+	err := run(cmd, nil, st, "invalid")
+	if err == nil {
+		t.Fatal("expected run to return error from ChangePin, but got nil")
+	}
+
+	const expected = "invalid pin file type. Valid options are text and task"
+	if err.Error() != expected {
+		t.Fatalf("unexpected error. want %q, got %q", expected, err)
+	}
+}


### PR DESCRIPTION
## Summary
- return `ChangePin` errors from the pin add command so Cobra can surface failures
- add a unit test that verifies a failing `ChangePin` propagates the error

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1e8717d8083259abdf4619ac16814