### PR TITLE
Update view exclusions to omit trash

### DIFF
--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -119,7 +119,7 @@ func (vm *ViewManager) GetFilesByView(
 	viewFlag string,
 	vaultDir string,
 ) ([]string, error) {
-	defaultExcludeDirs := []string{"archive"}
+	defaultExcludeDirs := []string{"archive", "trash"}
 	defaultExcludeFiles := []string{}
 
 	var (

--- a/internal/views/views_test.go
+++ b/internal/views/views_test.go
@@ -78,6 +78,14 @@ func TestGetFilesByView_DefaultAndArchive(t *testing.T) {
 			t.Fatalf("custom view unexpectedly contained excluded file %s", skipPath)
 		}
 
+		if contains(files, trashedPath) {
+			t.Fatalf("custom view unexpectedly contained trashed file %s", trashedPath)
+		}
+
+		if contains(files, archivedPath) {
+			t.Fatalf("custom view unexpectedly contained archived file %s", archivedPath)
+		}
+
 		if !contains(files, keepPath) {
 			t.Fatalf("custom view missing expected file %s", keepPath)
 		}


### PR DESCRIPTION
## Summary
- ensure views with no explicit exclusions skip both archive and trash directories by default
- extend custom view test coverage to assert trashed and archived notes stay hidden when no exclude list is set

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1ee7fdd048325a5da9f33fb344098