### PR TITLE
Handle invalid priority fallback

### DIFF
--- a/pkg/cmd/tasks/taskEcho/taskEcho.go
+++ b/pkg/cmd/tasks/taskEcho/taskEcho.go
@@ -91,9 +91,11 @@ func run(cmd *cobra.Command, args []string, s *state.State, priority string) err
 		}
 	}
 
-	section := prioritySections[priority]
-	if section == "" {
-		section = prioritySections["low"]
+	normalizedPriority := strings.ToLower(priority)
+	section, ok := prioritySections[normalizedPriority]
+	if !ok {
+		normalizedPriority = "low"
+		section = prioritySections[normalizedPriority]
 	}
 
 	sectionIndex := strings.Index(contentStr, section) + len(section)
@@ -123,12 +125,12 @@ func run(cmd *cobra.Command, args []string, s *state.State, priority string) err
 		fmt.Printf(
 			"Task appended to the pinned named task file '%s' under the \"%s\" section.\n",
 			name,
-			priority,
+			normalizedPriority,
 		)
 	} else {
 		fmt.Printf(
 			"Task appended to the pinned task file under the \"%s\" section.\n",
-			priority,
+			normalizedPriority,
 		)
 	}
 	return nil

--- a/pkg/cmd/tasks/taskEcho/taskEcho_test.go
+++ b/pkg/cmd/tasks/taskEcho/taskEcho_test.go
@@ -1,0 +1,81 @@
+package taskEcho
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/state"
+)
+
+func TestRun_InvalidPriorityFallsBackToLow(t *testing.T) {
+	tmpDir := t.TempDir()
+	taskFile := filepath.Join(tmpDir, "tasks.md")
+	initialContent := "## Tasks\n### Low Priority\n### Medium Priority\n### High Priority\n"
+
+	if err := os.WriteFile(taskFile, []byte(initialContent), 0o644); err != nil {
+		t.Fatalf("failed to write initial task file: %v", err)
+	}
+
+	st := &state.State{Config: &config.Config{PinnedTaskFile: taskFile}}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("name", "n", "", "")
+
+	originalStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	os.Stdout = w
+
+	runErr := run(cmd, []string{"New task"}, st, "urgent")
+
+	w.Close()
+	os.Stdout = originalStdout
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to copy stdout: %v", err)
+	}
+	r.Close()
+	output := buf.String()
+
+	if runErr != nil {
+		t.Fatalf("run returned error: %v", runErr)
+	}
+
+	trimmedOutput := strings.TrimSpace(output)
+	expectedMessage := "Task appended to the pinned task file under the \"low\" section."
+	if trimmedOutput != expectedMessage {
+		t.Fatalf("unexpected output message: got %q, want %q", trimmedOutput, expectedMessage)
+	}
+
+	content, err := os.ReadFile(taskFile)
+	if err != nil {
+		t.Fatalf("failed to read task file: %v", err)
+	}
+	contentStr := string(content)
+
+	entry := "- [ ] New task\n"
+	if !strings.Contains(contentStr, entry) {
+		t.Fatalf("task entry %q not found in task file", entry)
+	}
+
+	lowIndex := strings.Index(contentStr, "### Low Priority")
+	entryIndex := strings.Index(contentStr, entry)
+	mediumIndex := strings.Index(contentStr, "### Medium Priority")
+
+	if lowIndex == -1 || mediumIndex == -1 {
+		t.Fatalf("priority sections missing from task file: low=%d medium=%d", lowIndex, mediumIndex)
+	}
+
+	if !(lowIndex < entryIndex && entryIndex < mediumIndex) {
+		t.Fatalf("task entry not placed under low priority section: low=%d entry=%d medium=%d", lowIndex, entryIndex, mediumIndex)
+	}
+}


### PR DESCRIPTION
## Summary
- normalize the requested priority in task echo and track the fallback section key
- ensure the success message reflects the effective priority
- add a regression test covering invalid priorities and the resulting placement

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1ef92f1948325ad0c9e38fc7eb9b0