### PR TITLE
Add vault watcher and async previews

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -130,6 +130,20 @@ func (c *Cache) removeElement(e *list.Element) {
 	c.currentSize -= int64(sizeof(kv))
 }
 
+// Delete removes the provided key from the cache if it exists.
+func (c *Cache) Delete(key interface{}) {
+	if key == nil {
+		return
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if ele, hit := c.items[key]; hit {
+		c.removeElement(ele)
+	}
+}
+
 // SizeOf returns the approximate memory usage in bytes of the cache.
 func (c *Cache) SizeOf() int64 {
 	return c.currentSize

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -21,6 +21,7 @@ type State struct {
 	Views       map[string]views.View
 	Home        string
 	Vault       string
+	Watcher     *VaultWatcher
 }
 
 func NewState() (*State, error) {
@@ -42,6 +43,11 @@ func NewState() (*State, error) {
 	h := handler.NewFileHandler(cfg.VaultDir)
 	vm := views.NewViewManager(h, cfg.VaultDir)
 
+	watcher, err := NewVaultWatcher(cfg.VaultDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vault watcher: %w", err)
+	}
+
 	return &State{
 		Config:      cfg,
 		Templater:   t,
@@ -50,6 +56,7 @@ func NewState() (*State, error) {
 		Views:       vm.Views,
 		Home:        home,
 		Vault:       cfg.VaultDir,
+		Watcher:     watcher,
 	}, nil
 }
 

--- a/internal/state/watcher.go
+++ b/internal/state/watcher.go
@@ -1,0 +1,158 @@
+package state
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/Paintersrp/an/internal/pathutil"
+)
+
+type VaultNoteChangedMsg struct {
+	Path string
+}
+
+type VaultWatcherErrMsg struct {
+	Err error
+}
+
+type VaultWatcher struct {
+	watcher *fsnotify.Watcher
+	vault   string
+	done    chan struct{}
+	once    sync.Once
+}
+
+func NewVaultWatcher(vault string) (*VaultWatcher, error) {
+	normalizedVault := pathutil.NormalizePath(vault)
+	if normalizedVault == "" {
+		return nil, errors.New("vault directory cannot be empty")
+	}
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	watcher := &VaultWatcher{
+		watcher: w,
+		vault:   normalizedVault,
+		done:    make(chan struct{}),
+	}
+
+	if err := watcher.addRecursive(normalizedVault); err != nil {
+		_ = watcher.Close()
+		return nil, err
+	}
+
+	return watcher, nil
+}
+
+func (w *VaultWatcher) Start() tea.Cmd {
+	if w == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		for {
+			select {
+			case <-w.done:
+				return nil
+			case event, ok := <-w.watcher.Events:
+				if !ok {
+					return nil
+				}
+
+				if event.Op&fsnotify.Create != 0 {
+					if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+						_ = w.addRecursive(event.Name)
+						continue
+					}
+				}
+
+				if !w.isRelevant(event) {
+					continue
+				}
+
+				rel, err := w.relativePath(event.Name)
+				if err != nil || rel == "" {
+					continue
+				}
+
+				return VaultNoteChangedMsg{Path: rel}
+			case err, ok := <-w.watcher.Errors:
+				if !ok {
+					return nil
+				}
+				if err != nil {
+					return VaultWatcherErrMsg{Err: err}
+				}
+			}
+		}
+	}
+}
+
+func (w *VaultWatcher) Close() error {
+	if w == nil {
+		return nil
+	}
+
+	var closeErr error
+	w.once.Do(func() {
+		close(w.done)
+		closeErr = w.watcher.Close()
+	})
+
+	return closeErr
+}
+
+func (w *VaultWatcher) addRecursive(root string) error {
+	normalized := pathutil.NormalizePath(root)
+	return filepath.WalkDir(normalized, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrPermission) {
+				return filepath.SkipDir
+			}
+			return err
+		}
+
+		if !d.IsDir() {
+			return nil
+		}
+
+		return w.watcher.Add(path)
+	})
+}
+
+func (w *VaultWatcher) isRelevant(event fsnotify.Event) bool {
+	if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove|fsnotify.Rename) == 0 {
+		return false
+	}
+
+	rel, err := w.relativePath(event.Name)
+	if err != nil || rel == "" {
+		return false
+	}
+
+	return strings.EqualFold(filepath.Ext(rel), ".md")
+}
+
+func (w *VaultWatcher) relativePath(path string) (string, error) {
+	normalized := pathutil.NormalizePath(path)
+	rel, err := pathutil.VaultRelative(w.vault, normalized)
+	if err != nil {
+		return "", err
+	}
+
+	if rel == "." || rel == "" || strings.HasPrefix(rel, "..") {
+		return "", nil
+	}
+
+	return rel, nil
+}


### PR DESCRIPTION
## Summary
- add an fsnotify-backed vault watcher that emits Bubble Tea messages when markdown notes change
- start the watcher from the note list, refresh items on events, and render previews asynchronously without blocking the UI
- expose cache eviction helpers so previews are invalidated when files change

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1f3b19840832592894858efafa17f