### PR TITLE
Add search index and integrate metadata filtering

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,13 @@ import (
 
 type PinMap map[string]string
 
+type SearchConfig struct {
+	EnableBody             bool                `yaml:"enable_body"             json:"enable_body"`
+	IgnoredFolders         []string            `yaml:"ignored_folders"         json:"ignored_folders"`
+	DefaultTagFilters      []string            `yaml:"tag_filters"             json:"tag_filters"`
+	DefaultMetadataFilters map[string][]string `yaml:"metadata_filters"        json:"metadata_filters"`
+}
+
 type Config struct {
 	PinManager     *pin.PinManager `yaml:"-"`
 	NamedPins      PinMap          `yaml:"named_pins"       json:"named_pins"`
@@ -25,6 +32,7 @@ type Config struct {
 	PinnedFile     string          `yaml:"pinned_file"      json:"pinned_file"`
 	PinnedTaskFile string          `yaml:"pinned_task_file" json:"pinned_task_file"`
 	SubDirs        []string        `yaml:"subdirs"          json:"sub_dirs"`
+	Search         SearchConfig    `yaml:"search"           json:"search"`
 }
 
 var ValidModes = map[string]bool{
@@ -80,7 +88,7 @@ func Load(home string) (*Config, error) {
 		return nil, err
 	}
 
-	cfg := &Config{}
+	cfg := &Config{Search: SearchConfig{EnableBody: true}}
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, err
 	}
@@ -96,6 +104,9 @@ func Load(home string) (*Config, error) {
 	}
 	if cfg.NamedTaskPins == nil {
 		cfg.NamedTaskPins = make(PinMap)
+	}
+	if cfg.Search.DefaultMetadataFilters == nil {
+		cfg.Search.DefaultMetadataFilters = make(map[string][]string)
 	}
 
 	cfg.PinManager = pin.NewPinManager(

--- a/internal/search/config.go
+++ b/internal/search/config.go
@@ -1,0 +1,30 @@
+package search
+
+// Config describes index behavior.
+type Config struct {
+	// EnableBody controls whether the index searches note bodies in addition to
+	// front matter and links.
+	EnableBody bool
+	// IgnoredFolders contains directory names that should be skipped when
+	// indexing. Paths containing any of these folders will not be indexed.
+	IgnoredFolders []string
+}
+
+// Query represents a search request against the index.
+type Query struct {
+	// Term is the free-text query to evaluate against indexed content.
+	Term string
+	// Tags enumerates tag names that must be present on the note. All tags must
+	// be satisfied for a document to match.
+	Tags []string
+	// Metadata filters require front-matter fields to contain one or more
+	// values. The values associated with a key are treated as an AND match.
+	Metadata map[string][]string
+}
+
+// Result captures a document match from the index.
+type Result struct {
+	Path      string
+	Snippet   string
+	MatchFrom string
+}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -1,0 +1,347 @@
+package search
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+type document struct {
+	Path        string
+	Tags        []string
+	FrontMatter map[string][]string
+	Links       []string
+	Body        string
+}
+
+// Index stores searchable representations of notes on disk.
+type Index struct {
+	root string
+	cfg  Config
+	docs map[string]document
+}
+
+// NewIndex constructs an empty index rooted at the provided directory.
+func NewIndex(root string, cfg Config) *Index {
+	return &Index{
+		root: filepath.Clean(root),
+		cfg:  cfg,
+		docs: make(map[string]document),
+	}
+}
+
+// Build replaces the index contents using the provided note paths.
+func (idx *Index) Build(paths []string) error {
+	idx.docs = make(map[string]document, len(paths))
+	for _, p := range paths {
+		if idx.shouldIgnore(p) {
+			continue
+		}
+
+		doc, err := idx.loadDocument(p)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("search: indexing %s: %w", p, err)
+		}
+		idx.docs[filepath.Clean(p)] = doc
+	}
+	return nil
+}
+
+// Search evaluates the provided query against the index and returns matching
+// note paths alongside snippets describing the match location.
+func (idx *Index) Search(q Query) []Result {
+	if len(idx.docs) == 0 {
+		return nil
+	}
+	term := strings.TrimSpace(q.Term)
+	loweredTerm := strings.ToLower(term)
+
+	results := make([]Result, 0)
+	for _, doc := range idx.docs {
+		if !doc.matchesFilters(q) {
+			continue
+		}
+
+		if loweredTerm == "" {
+			// Pure metadata filtering request.
+			results = append(results, Result{Path: doc.Path, MatchFrom: "metadata"})
+			continue
+		}
+
+		if snippet, ok := doc.matchFrontMatter(loweredTerm); ok {
+			results = append(results, Result{Path: doc.Path, Snippet: snippet, MatchFrom: "frontmatter"})
+			continue
+		}
+
+		if snippet, ok := doc.matchLinks(loweredTerm); ok {
+			results = append(results, Result{Path: doc.Path, Snippet: snippet, MatchFrom: "links"})
+			continue
+		}
+
+		if idx.cfg.EnableBody {
+			if snippet, ok := doc.matchBody(loweredTerm); ok {
+				results = append(results, Result{Path: doc.Path, Snippet: snippet, MatchFrom: "body"})
+				continue
+			}
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].Path < results[j].Path
+	})
+	return results
+}
+
+func (idx *Index) shouldIgnore(path string) bool {
+	rel, err := filepath.Rel(idx.root, path)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	parts := strings.Split(rel, "/")
+	for _, segment := range parts {
+		for _, ignored := range idx.cfg.IgnoredFolders {
+			if ignored == "" {
+				continue
+			}
+			if strings.EqualFold(segment, ignored) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (idx *Index) loadDocument(path string) (document, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return document{}, err
+	}
+
+	fm, body := splitFrontMatter(data)
+	parsed, tags, err := parseFrontMatter(fm)
+	if err != nil {
+		return document{}, fmt.Errorf("parse front matter: %w", err)
+	}
+
+	return document{
+		Path:        filepath.Clean(path),
+		Tags:        tags,
+		FrontMatter: parsed,
+		Links:       extractLinks(body),
+		Body:        string(body),
+	}, nil
+}
+
+func (d document) matchesFilters(q Query) bool {
+	if len(q.Tags) > 0 {
+		for _, required := range q.Tags {
+			if !containsFold(d.Tags, required) {
+				return false
+			}
+		}
+	}
+
+	if len(q.Metadata) == 0 {
+		return true
+	}
+
+	for key, values := range q.Metadata {
+		available, ok := d.FrontMatter[key]
+		if !ok {
+			return false
+		}
+		for _, want := range values {
+			if !containsFold(available, want) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (d document) matchFrontMatter(term string) (string, bool) {
+	for key, values := range d.FrontMatter {
+		for _, value := range values {
+			if strings.Contains(strings.ToLower(value), term) {
+				return fmt.Sprintf("%s: %s", key, value), true
+			}
+		}
+	}
+	return "", false
+}
+
+func (d document) matchLinks(term string) (string, bool) {
+	for _, link := range d.Links {
+		if strings.Contains(strings.ToLower(link), term) {
+			return fmt.Sprintf("link: %s", link), true
+		}
+	}
+	return "", false
+}
+
+func (d document) matchBody(term string) (string, bool) {
+	lowered := strings.ToLower(d.Body)
+	idx := strings.Index(lowered, term)
+	if idx == -1 {
+		return "", false
+	}
+	runeStart := utf8.RuneCountInString(lowered[:idx])
+	return bodySnippet(d.Body, runeStart, utf8.RuneCountInString(term)), true
+}
+
+func containsFold(values []string, target string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitFrontMatter(data []byte) ([]byte, []byte) {
+	re := regexp.MustCompile(`(?ms)^---\s*\n(.*?)\n---\s*\n?`)
+	loc := re.FindSubmatchIndex(data)
+	if len(loc) < 4 {
+		return nil, data
+	}
+	yamlStart := loc[2]
+	yamlEnd := loc[3]
+	bodyStart := loc[1]
+	fm := data[yamlStart:yamlEnd]
+	body := data[bodyStart:]
+	return fm, body
+}
+
+func parseFrontMatter(fm []byte) (map[string][]string, []string, error) {
+	result := make(map[string][]string)
+	var tags []string
+	if len(fm) == 0 {
+		return result, tags, nil
+	}
+
+	var data yaml.Node
+	if err := yaml.Unmarshal(fm, &data); err != nil {
+		return nil, nil, err
+	}
+
+	if data.Kind != yaml.DocumentNode || len(data.Content) == 0 {
+		return result, tags, nil
+	}
+
+	mapping := data.Content[0]
+	if mapping.Kind != yaml.MappingNode {
+		return result, tags, nil
+	}
+
+	for i := 0; i < len(mapping.Content); i += 2 {
+		keyNode := mapping.Content[i]
+		valueNode := mapping.Content[i+1]
+		key := keyNode.Value
+
+		values := flattenYAMLValue(valueNode)
+		result[key] = values
+		if key == "tags" {
+			tags = values
+		}
+	}
+
+	return result, tags, nil
+}
+
+func flattenYAMLValue(node *yaml.Node) []string {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		vals := make([]string, 0, len(node.Content))
+		for _, child := range node.Content {
+			vals = append(vals, child.Value)
+		}
+		return vals
+	case yaml.ScalarNode:
+		return []string{node.Value}
+	default:
+		return nil
+	}
+}
+
+func extractLinks(content []byte) []string {
+	body := string(content)
+	links := make(map[string]struct{})
+
+	wikiRe := regexp.MustCompile(`\[\[(.+?)\]\]`)
+	for _, match := range wikiRe.FindAllStringSubmatch(body, -1) {
+		if len(match) > 1 {
+			links[strings.TrimSpace(match[1])] = struct{}{}
+		}
+	}
+
+	mdRe := regexp.MustCompile(`\[[^\]]+\]\(([^)]+)\)`)
+	for _, match := range mdRe.FindAllStringSubmatch(body, -1) {
+		if len(match) > 1 {
+			links[strings.TrimSpace(match[1])] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(links))
+	for link := range links {
+		out = append(out, link)
+	}
+
+	sort.Strings(out)
+	return out
+}
+
+func bodySnippet(body string, index, termLen int) string {
+	if termLen <= 0 {
+		termLen = 1
+	}
+
+	runes := []rune(body)
+	start := index
+	end := index + termLen
+	if start < 0 {
+		start = 0
+	}
+	if end > len(runes) {
+		end = len(runes)
+	}
+
+	const window = 40
+	snippetStart := max(0, start-window)
+	snippetEnd := min(len(runes), end+window)
+
+	snippet := string(runes[snippetStart:snippetEnd])
+	snippet = strings.TrimSpace(snippet)
+	if snippetStart > 0 {
+		snippet = "…" + snippet
+	}
+	if snippetEnd < len(runes) {
+		snippet = snippet + "…"
+	}
+	return snippet
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/search/index_test.go
+++ b/internal/search/index_test.go
@@ -1,0 +1,108 @@
+package search
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeNote(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file %s: %v", path, err)
+	}
+	return path
+}
+
+func TestIndexSearchBodyRespectsToggle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	note := writeNote(t, dir, "note.md", "---\ntitle: Example\n---\nbody term here")
+
+	idx := NewIndex(dir, Config{EnableBody: true})
+	if err := idx.Build([]string{note}); err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	results := idx.Search(Query{Term: "term"})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result with body search enabled, got %d", len(results))
+	}
+
+	idx = NewIndex(dir, Config{EnableBody: false})
+	if err := idx.Build([]string{note}); err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	results = idx.Search(Query{Term: "term"})
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results with body search disabled, got %d", len(results))
+	}
+}
+
+func TestIndexSearchIgnoredFolders(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	included := writeNote(t, dir, "keep/note.md", "---\ntitle: Keep\n---\nbody")
+	ignored := writeNote(t, dir, "archive/skip.md", "---\ntitle: Skip\n---\nbody skip")
+
+	idx := NewIndex(dir, Config{EnableBody: true, IgnoredFolders: []string{"archive"}})
+	if err := idx.Build([]string{included, ignored}); err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	results := idx.Search(Query{Term: "skip"})
+	if len(results) != 0 {
+		t.Fatalf("expected ignored folder to be skipped, got %d results", len(results))
+	}
+
+	results = idx.Search(Query{Term: "keep"})
+	if len(results) != 1 {
+		t.Fatalf("expected included note to be searchable, got %d results", len(results))
+	}
+}
+
+func TestIndexSearchSupportsMetadataAndTags(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	matched := writeNote(t, dir, "projects/plan.md", "---\ntitle: Plan\ntags:\n  - project\n  - urgent\nstatus: active\n---\nMilestone body\n")
+	archived := writeNote(t, dir, "projects/archive.md", "---\ntitle: Old\ntags:\n  - project\nstatus: done\n---\nFinished body\n")
+
+	idx := NewIndex(dir, Config{EnableBody: true})
+	if err := idx.Build([]string{matched, archived}); err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	query := Query{
+		Term: "milestone",
+		Tags: []string{"project"},
+		Metadata: map[string][]string{
+			"status": []string{"active"},
+		},
+	}
+
+	results := idx.Search(query)
+	if len(results) != 1 || results[0].Path != filepath.Clean(matched) {
+		t.Fatalf("expected matching note, got %+v", results)
+	}
+
+	// Metadata-only queries should still filter results.
+	query.Term = ""
+	results = idx.Search(query)
+	if len(results) != 1 || results[0].Path != filepath.Clean(matched) {
+		t.Fatalf("expected metadata filters to return match, got %+v", results)
+	}
+
+	query.Metadata["status"] = []string{"missing"}
+	results = idx.Search(query)
+	if len(results) != 0 {
+		t.Fatalf("expected metadata filters to exclude non-matching notes, got %+v", results)
+	}
+}

--- a/internal/tui/notes/highlights.go
+++ b/internal/tui/notes/highlights.go
@@ -1,0 +1,42 @@
+package notes
+
+import (
+	"sync"
+
+	"github.com/Paintersrp/an/internal/search"
+)
+
+type highlightStore struct {
+	mu      sync.RWMutex
+	matches map[string]search.Result
+}
+
+func newHighlightStore() *highlightStore {
+	return &highlightStore{matches: make(map[string]search.Result)}
+}
+
+func (s *highlightStore) setAll(entries map[string]search.Result) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(entries) == 0 {
+		s.matches = make(map[string]search.Result)
+		return
+	}
+
+	s.matches = make(map[string]search.Result, len(entries))
+	for path, result := range entries {
+		s.matches[path] = result
+	}
+}
+
+func (s *highlightStore) clear() {
+	s.setAll(nil)
+}
+
+func (s *highlightStore) lookup(path string) (search.Result, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result, ok := s.matches[path]
+	return result, ok
+}

--- a/internal/tui/notes/items.go
+++ b/internal/tui/notes/items.go
@@ -16,6 +16,7 @@ type ListItem struct {
 	tags         []string
 	size         int64
 	showFullPath bool
+	highlights   *highlightStore
 }
 
 func (i ListItem) Title() string {
@@ -48,19 +49,38 @@ func (i ListItem) Description() string {
 			description += strings.Join(i.tags, ", ")
 		}
 	}
+	if snippet := i.highlightSnippet(); snippet != "" {
+		if description != "" {
+			description += "\n"
+		}
+		description += snippet
+	}
+
 	return description
 }
 
 func (i ListItem) FilterValue() string {
-        str := strings.Join(i.tags, " ")
-        return fmt.Sprintf(
-                "%s [%s] [%s]",
-                i.Title(),
-                str,
-                i.subdirectory,
-        )
+	str := strings.Join(i.tags, " ")
+	parts := []string{i.Title(), "[" + str + "]", "[" + i.subdirectory + "]"}
+	if snippet := i.highlightSnippet(); snippet != "" {
+		parts = append(parts, snippet)
+	}
+	return strings.Join(parts, " ")
 }
 
 func (i ListItem) Path() string {
 	return i.path
+}
+
+func (i ListItem) highlightSnippet() string {
+	if i.highlights == nil {
+		return ""
+	}
+	if res, ok := i.highlights.lookup(i.path); ok {
+		if res.Snippet != "" {
+			return res.Snippet
+		}
+		return res.MatchFrom
+	}
+	return ""
 }

--- a/internal/tui/notes/items_test.go
+++ b/internal/tui/notes/items_test.go
@@ -1,6 +1,10 @@
 package notes
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Paintersrp/an/internal/search"
+)
 
 func TestListItemFilterValueUsesTitle(t *testing.T) {
 	t.Parallel()
@@ -31,5 +35,51 @@ func TestListItemFilterValueFallsBackToFilename(t *testing.T) {
 
 	if got != want {
 		t.Fatalf("FilterValue() = %q, want %q", got, want)
+	}
+}
+
+func TestListItemFilterValueIncludesHighlight(t *testing.T) {
+	t.Parallel()
+
+	store := newHighlightStore()
+	path := "/tmp/note.md"
+	store.setAll(map[string]search.Result{
+		path: search.Result{Snippet: "matched snippet"},
+	})
+
+	item := ListItem{
+		fileName:   "note.md",
+		path:       path,
+		highlights: store,
+	}
+
+	got := item.FilterValue()
+	want := "note [] [] matched snippet"
+
+	if got != want {
+		t.Fatalf("FilterValue() = %q, want %q", got, want)
+	}
+}
+
+func TestListItemDescriptionIncludesHighlight(t *testing.T) {
+	t.Parallel()
+
+	store := newHighlightStore()
+	path := "/tmp/note.md"
+	store.setAll(map[string]search.Result{
+		path: search.Result{Snippet: "body match"},
+	})
+
+	item := ListItem{
+		fileName:   "note.md",
+		highlights: store,
+		path:       path,
+	}
+
+	got := item.Description()
+	want := "No tags\nbody match"
+
+	if got != want {
+		t.Fatalf("Description() = %q, want %q", got, want)
 	}
 }

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -21,11 +21,12 @@ func TestCycleViewOrder(t *testing.T) {
 	l := list.New([]list.Item{}, delegate, 0, 0)
 
 	model := &NoteListModel{
-		list:      l,
-		state:     &state.State{Handler: fileHandler, ViewManager: viewManager, Vault: tempDir},
-		viewName:  "default",
-		sortField: sortByTitle,
-		sortOrder: ascending,
+		list:       l,
+		state:      &state.State{Handler: fileHandler, ViewManager: viewManager, Vault: tempDir},
+		viewName:   "default",
+		sortField:  sortByTitle,
+		sortOrder:  ascending,
+		highlights: newHighlightStore(),
 	}
 
 	expectedOrder := []string{"unfulfilled", "archive", "orphan", "trash", "default"}

--- a/internal/tui/notes/utils.go
+++ b/internal/tui/notes/utils.go
@@ -284,3 +284,15 @@ func castToListItems(items []list.Item) []ListItem {
 	}
 	return listItems
 }
+
+func attachHighlightStore(items []list.Item, store *highlightStore) {
+	if store == nil {
+		return
+	}
+	for i, item := range items {
+		if listItem, ok := item.(ListItem); ok {
+			listItem.highlights = store
+			items[i] = listItem
+		}
+	}
+}

--- a/internal/tui/notes/utils_test.go
+++ b/internal/tui/notes/utils_test.go
@@ -16,6 +16,8 @@ func newTestNoteListModel(t *testing.T, item ListItem, inputValue string) NoteLi
 	t.Helper()
 
 	delegate := list.NewDefaultDelegate()
+	store := newHighlightStore()
+	item.highlights = store
 	l := list.New([]list.Item{item}, delegate, 0, 0)
 	l.Select(0)
 
@@ -24,6 +26,7 @@ func newTestNoteListModel(t *testing.T, item ListItem, inputValue string) NoteLi
 
 	return NoteListModel{
 		list:       l,
+		highlights: store,
 		inputModel: inputModel,
 	}
 }


### PR DESCRIPTION
## Summary
- add a search index package that builds searchable note metadata, links, and bodies with configurable behaviour
- extend the note list model to combine indexed results with existing filters and surface highlight snippets
- update configuration and tests to cover metadata/tag filtering and highlight-aware list items

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1f7279f1083259faa5e9e32a571d3