### PR TITLE
Add workspace-aware configuration and CLI tooling

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,24 @@ import (
 	"github.com/Paintersrp/an/internal/config"
 )
 
+func writeConfigFile(t *testing.T, home string, data map[string]any) {
+	t.Helper()
+
+	configPath := config.GetConfigPath(home)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("failed to create config directory: %v", err)
+	}
+
+	bytes, err := yaml.Marshal(data)
+	if err != nil {
+		t.Fatalf("failed to marshal config data: %v", err)
+	}
+
+	if err := os.WriteFile(configPath, bytes, 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+}
+
 func TestLoadAcceptsSupportedEditors(t *testing.T) {
 	editors := []string{"nvim", "obsidian", "vscode", "vim", "nano"}
 
@@ -19,38 +37,26 @@ func TestLoadAcceptsSupportedEditors(t *testing.T) {
 		editor := editor
 		t.Run(editor, func(t *testing.T) {
 			home := t.TempDir()
-			configPath := config.GetConfigPath(home)
-
-			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-				t.Fatalf("failed to create config directory: %v", err)
-			}
-
 			cfgData := map[string]any{
-				"vaultdir":         filepath.Join(home, "vault"),
-				"editor":           editor,
-				"nvimargs":         "",
-				"fsmode":           "strict",
-				"pinned_file":      "",
-				"pinned_task_file": "",
-				"subdirs":          []string{},
+				"current_workspace": "main",
+				"workspaces": map[string]any{
+					"main": map[string]any{
+						"vaultdir": filepath.Join(home, "vault"),
+						"editor":   editor,
+						"fsmode":   "strict",
+					},
+				},
 			}
 
-			data, err := yaml.Marshal(cfgData)
-			if err != nil {
-				t.Fatalf("failed to marshal config data: %v", err)
-			}
-
-			if err := os.WriteFile(configPath, data, 0o644); err != nil {
-				t.Fatalf("failed to write config file: %v", err)
-			}
+			writeConfigFile(t, home, cfgData)
 
 			cfg, err := config.Load(home)
 			if err != nil {
 				t.Fatalf("expected load to succeed for editor %q: %v", editor, err)
 			}
 
-			if cfg.Editor != editor {
-				t.Fatalf("expected editor %q, got %q", editor, cfg.Editor)
+			if got := cfg.MustWorkspace().Editor; got != editor {
+				t.Fatalf("expected editor %q, got %q", editor, got)
 			}
 		})
 	}
@@ -58,38 +64,61 @@ func TestLoadAcceptsSupportedEditors(t *testing.T) {
 
 func TestLoadRejectsUnsupportedEditor(t *testing.T) {
 	home := t.TempDir()
-	configPath := config.GetConfigPath(home)
-
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("failed to create config directory: %v", err)
-	}
-
 	cfgData := map[string]any{
-		"vaultdir":         filepath.Join(home, "vault"),
-		"editor":           "unsupported", // ensure validation fails
-		"nvimargs":         "",
-		"fsmode":           "strict",
-		"pinned_file":      "",
-		"pinned_task_file": "",
-		"subdirs":          []string{},
+		"current_workspace": "main",
+		"workspaces": map[string]any{
+			"main": map[string]any{
+				"vaultdir": filepath.Join(home, "vault"),
+				"editor":   "unsupported",
+				"fsmode":   "strict",
+			},
+		},
 	}
 
-	data, err := yaml.Marshal(cfgData)
-	if err != nil {
-		t.Fatalf("failed to marshal config data: %v", err)
-	}
+	writeConfigFile(t, home, cfgData)
 
-	if err := os.WriteFile(configPath, data, 0o644); err != nil {
-		t.Fatalf("failed to write config file: %v", err)
-	}
-
-	_, err = config.Load(home)
+	_, err := config.Load(home)
 	if err == nil {
 		t.Fatal("expected load to fail for unsupported editor")
 	}
 
-	if !strings.Contains(err.Error(), "invalid editor") {
-		t.Fatalf("expected invalid editor error, got %v", err)
+	if want := "invalid editor"; err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected error containing %q, got %v", want, err)
+	}
+}
+
+func TestLoadMigratesLegacyConfig(t *testing.T) {
+	home := t.TempDir()
+	legacy := map[string]any{
+		"vaultdir": filepath.Join(home, "vault"),
+		"editor":   "vim",
+		"fsmode":   "confirm",
+		"subdirs":  []string{"atoms"},
+	}
+
+	writeConfigFile(t, home, legacy)
+
+	cfg, err := config.Load(home)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if cfg.CurrentWorkspace != "default" {
+		t.Fatalf("expected default workspace, got %q", cfg.CurrentWorkspace)
+	}
+
+	ws := cfg.MustWorkspace()
+	if ws.VaultDir != filepath.Join(home, "vault") {
+		t.Fatalf("expected migrated vaultdir, got %q", ws.VaultDir)
+	}
+	if ws.Editor != "vim" {
+		t.Fatalf("expected migrated editor, got %q", ws.Editor)
+	}
+	if ws.FileSystemMode != "confirm" {
+		t.Fatalf("expected migrated fs mode, got %q", ws.FileSystemMode)
+	}
+	if !slices.Contains(ws.SubDirs, "atoms") {
+		t.Fatalf("expected migrated subdirs to include atoms: %#v", ws.SubDirs)
 	}
 }
 
@@ -97,32 +126,25 @@ func TestSaveWithNoEditorSkipsValidation(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	configPath := config.GetConfigPath(home)
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		t.Fatalf("failed to create config directory: %v", err)
-	}
-
 	cfgData := map[string]any{
-		"vaultdir": filepath.Join(home, "vault"),
-		"subdirs":  []string{},
+		"current_workspace": "main",
+		"workspaces": map[string]any{
+			"main": map[string]any{
+				"vaultdir": filepath.Join(home, "vault"),
+				"fsmode":   "strict",
+			},
+		},
 	}
 
-	data, err := yaml.Marshal(cfgData)
-	if err != nil {
-		t.Fatalf("failed to marshal config data: %v", err)
-	}
-
-	if err := os.WriteFile(configPath, data, 0o644); err != nil {
-		t.Fatalf("failed to write config file: %v", err)
-	}
+	writeConfigFile(t, home, cfgData)
 
 	cfg, err := config.Load(home)
 	if err != nil {
 		t.Fatalf("Load returned error: %v", err)
 	}
 
-	if cfg.Editor != "" {
-		t.Fatalf("expected empty editor, got %q", cfg.Editor)
+	if cfg.MustWorkspace().Editor != "" {
+		t.Fatalf("expected empty editor, got %q", cfg.MustWorkspace().Editor)
 	}
 
 	if err := cfg.AddSubdir("atoms"); err != nil {
@@ -134,26 +156,39 @@ func TestSaveWithNoEditorSkipsValidation(t *testing.T) {
 		t.Fatalf("reloading config: %v", err)
 	}
 
-	if !slices.Contains(reloaded.SubDirs, "atoms") {
-		t.Fatalf("expected persisted SubDirs to include 'atoms': %#v", reloaded.SubDirs)
+	if !slices.Contains(reloaded.MustWorkspace().SubDirs, "atoms") {
+		t.Fatalf("expected persisted SubDirs to include 'atoms': %#v", reloaded.MustWorkspace().SubDirs)
 	}
 }
 
 func TestConfigAddSubdirPersistsChanges(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
-	cfg := &config.Config{
-		Editor:         "nvim",
-		FileSystemMode: "strict",
-		SubDirs:        []string{"existing"},
+	cfgData := map[string]any{
+		"current_workspace": "main",
+		"workspaces": map[string]any{
+			"main": map[string]any{
+				"vaultdir": filepath.Join(home, "vault"),
+				"editor":   "nvim",
+				"fsmode":   "strict",
+				"subdirs":  []string{"existing"},
+			},
+		},
+	}
+	writeConfigFile(t, home, cfgData)
+
+	cfg, err := config.Load(home)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
 	}
 
 	if err := cfg.AddSubdir("atoms"); err != nil {
 		t.Fatalf("AddSubdir returned error: %v", err)
 	}
 
-	if !slices.Contains(cfg.SubDirs, "atoms") {
-		t.Fatalf("expected in-memory SubDirs to include 'atoms': %#v", cfg.SubDirs)
+	if !slices.Contains(cfg.MustWorkspace().SubDirs, "atoms") {
+		t.Fatalf("expected in-memory SubDirs to include 'atoms': %#v", cfg.MustWorkspace().SubDirs)
 	}
 
 	data, err := os.ReadFile(cfg.GetConfigPath())
@@ -161,13 +196,24 @@ func TestConfigAddSubdirPersistsChanges(t *testing.T) {
 		t.Fatalf("reading persisted config: %v", err)
 	}
 
-	var persisted config.Config
+	var persisted map[string]any
 	if err := yaml.Unmarshal(data, &persisted); err != nil {
 		t.Fatalf("unmarshal persisted config: %v", err)
 	}
 
-	if !slices.Contains(persisted.SubDirs, "atoms") {
-		t.Fatalf("expected persisted SubDirs to include 'atoms': %#v", persisted.SubDirs)
+	workspaces := persisted["workspaces"].(map[string]any)
+	main := workspaces["main"].(map[string]any)
+	subdirs := main["subdirs"].([]any)
+
+	found := false
+	for _, v := range subdirs {
+		if v.(string) == "atoms" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected persisted SubDirs to include 'atoms': %#v", subdirs)
 	}
 
 	if err := cfg.AddSubdir("atoms"); err == nil {
@@ -179,18 +225,33 @@ func TestConfigAddAndRemoveView(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	cfg := &config.Config{VaultDir: filepath.Join(home, "vault")}
+	cfgData := map[string]any{
+		"current_workspace": "main",
+		"workspaces": map[string]any{
+			"main": map[string]any{
+				"vaultdir": filepath.Join(home, "vault"),
+				"editor":   "vim",
+				"fsmode":   "strict",
+			},
+		},
+	}
+	writeConfigFile(t, home, cfgData)
+
+	cfg, err := config.Load(home)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
 
 	if err := cfg.AddView("custom", config.ViewDefinition{Include: []string{"notes"}}); err != nil {
 		t.Fatalf("AddView returned error: %v", err)
 	}
 
-	if _, ok := cfg.Views["custom"]; !ok {
-		t.Fatalf("expected in-memory Views to include 'custom': %#v", cfg.Views)
+	if _, ok := cfg.MustWorkspace().Views["custom"]; !ok {
+		t.Fatalf("expected in-memory Views to include 'custom': %#v", cfg.MustWorkspace().Views)
 	}
 
-	if !slices.Contains(cfg.ViewOrder, "custom") {
-		t.Fatalf("expected ViewOrder to include 'custom': %#v", cfg.ViewOrder)
+	if !slices.Contains(cfg.MustWorkspace().ViewOrder, "custom") {
+		t.Fatalf("expected ViewOrder to include 'custom': %#v", cfg.MustWorkspace().ViewOrder)
 	}
 
 	data, err := os.ReadFile(cfg.GetConfigPath())
@@ -198,24 +259,76 @@ func TestConfigAddAndRemoveView(t *testing.T) {
 		t.Fatalf("reading persisted config: %v", err)
 	}
 
-	var persisted config.Config
+	var persisted map[string]any
 	if err := yaml.Unmarshal(data, &persisted); err != nil {
 		t.Fatalf("unmarshal persisted config: %v", err)
 	}
 
-	if _, ok := persisted.Views["custom"]; !ok {
-		t.Fatalf("expected persisted Views to include 'custom': %#v", persisted.Views)
+	workspaces := persisted["workspaces"].(map[string]any)
+	main := workspaces["main"].(map[string]any)
+	views := main["views"].(map[string]any)
+	if _, ok := views["custom"]; !ok {
+		t.Fatalf("expected persisted Views to include 'custom': %#v", views)
 	}
 
 	if err := cfg.RemoveView("custom"); err != nil {
 		t.Fatalf("RemoveView returned error: %v", err)
 	}
 
-	if _, ok := cfg.Views["custom"]; ok {
-		t.Fatalf("expected view 'custom' to be removed: %#v", cfg.Views)
+	if _, ok := cfg.MustWorkspace().Views["custom"]; ok {
+		t.Fatalf("expected view 'custom' to be removed: %#v", cfg.MustWorkspace().Views)
 	}
 
-	if slices.Contains(cfg.ViewOrder, "custom") {
-		t.Fatalf("expected ViewOrder to exclude 'custom': %#v", cfg.ViewOrder)
+	if slices.Contains(cfg.MustWorkspace().ViewOrder, "custom") {
+		t.Fatalf("expected ViewOrder to exclude 'custom': %#v", cfg.MustWorkspace().ViewOrder)
+	}
+}
+
+func TestWorkspaceSwitchPersists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfgData := map[string]any{
+		"current_workspace": "primary",
+		"workspaces": map[string]any{
+			"primary": map[string]any{
+				"vaultdir": filepath.Join(home, "vault1"),
+				"editor":   "nvim",
+				"fsmode":   "strict",
+			},
+			"secondary": map[string]any{
+				"vaultdir": filepath.Join(home, "vault2"),
+				"editor":   "vim",
+				"fsmode":   "confirm",
+			},
+		},
+	}
+	writeConfigFile(t, home, cfgData)
+
+	cfg, err := config.Load(home)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if err := cfg.SwitchWorkspace("secondary"); err != nil {
+		t.Fatalf("SwitchWorkspace returned error: %v", err)
+	}
+
+	if cfg.CurrentWorkspace != "secondary" {
+		t.Fatalf("expected current workspace to be secondary, got %q", cfg.CurrentWorkspace)
+	}
+
+	ws := cfg.MustWorkspace()
+	if ws.VaultDir != filepath.Join(home, "vault2") {
+		t.Fatalf("expected active workspace to switch vaultdir, got %q", ws.VaultDir)
+	}
+
+	reloaded, err := config.Load(home)
+	if err != nil {
+		t.Fatalf("reloading config: %v", err)
+	}
+
+	if reloaded.CurrentWorkspace != "secondary" {
+		t.Fatalf("expected persisted current workspace to be secondary, got %q", reloaded.CurrentWorkspace)
 	}
 }

--- a/internal/note/note_test.go
+++ b/internal/note/note_test.go
@@ -15,7 +15,7 @@ func TestCreateCleansUpOnTemplateError(t *testing.T) {
 	subDir := filepath.Join("foo", "bar")
 	note := NewZettelkastenNote(vaultDir, subDir, "test-note", nil, nil, "")
 
-	tmpl, err := templater.NewTemplater()
+	tmpl, err := templater.NewTemplater(nil)
 	if err != nil {
 		t.Fatalf("failed to create templater: %v", err)
 	}

--- a/internal/templater/templater_test.go
+++ b/internal/templater/templater_test.go
@@ -31,7 +31,7 @@ func TestNewTemplaterRegistersUserTemplate(t *testing.T) {
 		}
 	}()
 
-	tmpl, err := NewTemplater()
+	tmpl, err := NewTemplater(nil)
 	if err != nil {
 		t.Fatalf("NewTemplater returned error: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestTemplaterExecuteUsesUserTemplateContent(t *testing.T) {
 		}
 	}()
 
-	templater, err := NewTemplater()
+	templater, err := NewTemplater(nil)
 	if err != nil {
 		t.Fatalf("NewTemplater returned error: %v", err)
 	}

--- a/internal/tui/initialize/init-prompt.go
+++ b/internal/tui/initialize/init-prompt.go
@@ -126,7 +126,8 @@ func (m InitPromptModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 
-				cfg := &config.Config{
+				workspaceName := "default"
+				ws := &config.Workspace{
 					VaultDir:       m.inputs[0].Value(),
 					Editor:         m.inputs[1].Value(),
 					NvimArgs:       m.inputs[2].Value(),
@@ -136,9 +137,20 @@ func (m InitPromptModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					PinnedTaskFile: defaults[6],
 				}
 
-				if err := config.ValidateEditor(cfg.Editor); err != nil {
+				cfg := &config.Config{
+					Workspaces: map[string]*config.Workspace{
+						workspaceName: ws,
+					},
+					CurrentWorkspace: workspaceName,
+				}
+
+				if err := config.ValidateEditor(ws.Editor); err != nil {
 					fmt.Println(err)
 					return m, nil
+				}
+
+				if err := cfg.ActivateWorkspace(workspaceName); err != nil {
+					panic(err)
 				}
 
 				cfgErr := cfg.Save()

--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -136,7 +136,8 @@ func (m *NoteListModel) rebuildSearch(paths []string) {
 		return
 	}
 
-	cfg := m.state.Config.Search
+	ws := m.state.Config.MustWorkspace()
+	cfg := ws.Search
 	searchCfg := search.Config{
 		EnableBody:     cfg.EnableBody,
 		IgnoredFolders: append([]string(nil), cfg.IgnoredFolders...),
@@ -340,7 +341,7 @@ func (m NoteListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			m.handleDefaultUpdate(msg)
 
-			if m.state.Config.Editor == "vim" || m.state.Config.Editor == "nano" {
+			if ws := m.state.Config.MustWorkspace(); ws.Editor == "vim" || ws.Editor == "nano" {
 				if key.Matches(msg, m.keys.openNote) {
 					return m, tea.Quit
 				}

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -16,7 +16,14 @@ func TestCycleViewOrder(t *testing.T) {
 
 	tempDir := t.TempDir()
 	fileHandler := handler.NewFileHandler(tempDir)
-	cfg := &config.Config{VaultDir: tempDir}
+	ws := &config.Workspace{VaultDir: tempDir}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
 	viewManager, err := views.NewViewManager(fileHandler, cfg)
 	if err != nil {
 		t.Fatalf("NewViewManager returned error: %v", err)
@@ -27,7 +34,7 @@ func TestCycleViewOrder(t *testing.T) {
 
 	model := &NoteListModel{
 		list:       l,
-		state:      &state.State{Config: cfg, Handler: fileHandler, ViewManager: viewManager, Vault: tempDir},
+		state:      &state.State{Config: cfg, Workspace: ws, WorkspaceName: cfg.CurrentWorkspace, Handler: fileHandler, ViewManager: viewManager, Vault: tempDir},
 		viewName:   "default",
 		sortField:  sortByTitle,
 		sortOrder:  ascending,

--- a/internal/tui/pinList/delgate.go
+++ b/internal/tui/pinList/delgate.go
@@ -44,10 +44,11 @@ func newItemDelegate(
 						pinType = "text"
 					}
 
+					ws := cfg.MustWorkspace()
 					if pinType == "task" {
-						cfg.PinnedTaskFile = description
+						ws.PinnedTaskFile = description
 					} else {
-						cfg.PinnedFile = description
+						ws.PinnedFile = description
 					}
 					if err := cfg.Save(); err != nil {
 						return m.NewStatusMessage(statusMessageStyle("Error saving the configuration: " + err.Error()))

--- a/internal/tui/pinList/pinList.go
+++ b/internal/tui/pinList/pinList.go
@@ -369,24 +369,25 @@ func (m *PinListModel) refreshDelegate(pinType string) {
 
 func getItemsByType(cfg *config.Config, pinType string) []list.Item {
 	var items []list.Item
+	ws := cfg.MustWorkspace()
 
 	switch pinType {
 	case "text":
-		names := make([]string, 0, len(cfg.NamedPins))
-		for name := range cfg.NamedPins {
+		names := make([]string, 0, len(ws.NamedPins))
+		for name := range ws.NamedPins {
 			names = append(names, name)
 		}
 		sort.Strings(names)
 
 		for _, name := range names {
-			path := cfg.NamedPins[name]
+			path := ws.NamedPins[name]
 			items = append(items, PinListItem{title: name, description: path})
 		}
 
-		if cfg.PinnedFile != "" {
+		if ws.PinnedFile != "" {
 			items = append(
 				items,
-				PinListItem{title: "default", description: cfg.PinnedFile},
+				PinListItem{title: "default", description: ws.PinnedFile},
 			)
 		} else {
 			items = append(
@@ -395,21 +396,21 @@ func getItemsByType(cfg *config.Config, pinType string) []list.Item {
 			)
 		}
 	case "task":
-		names := make([]string, 0, len(cfg.NamedTaskPins))
-		for name := range cfg.NamedTaskPins {
+		names := make([]string, 0, len(ws.NamedTaskPins))
+		for name := range ws.NamedTaskPins {
 			names = append(names, name)
 		}
 		sort.Strings(names)
 
 		for _, name := range names {
-			path := cfg.NamedTaskPins[name]
+			path := ws.NamedTaskPins[name]
 			items = append(items, PinListItem{title: name, description: path})
 		}
 
-		if cfg.PinnedTaskFile != "" {
+		if ws.PinnedTaskFile != "" {
 			items = append(
 				items,
-				PinListItem{title: "default", description: cfg.PinnedTaskFile},
+				PinListItem{title: "default", description: ws.PinnedTaskFile},
 			)
 		} else {
 			items = append(

--- a/internal/tui/pinList/submodels/sublist/delgate.go
+++ b/internal/tui/pinList/submodels/sublist/delgate.go
@@ -22,7 +22,7 @@ func newItemDelegate(keys *delegateKeyMap, cfg *config.Config) list.DefaultDeleg
 
 			switch {
 			case key.Matches(msg, keys.choose):
-				fmt.Println(msg, cfg.VaultDir)
+				fmt.Println(msg, cfg.MustWorkspace().VaultDir)
 				return nil
 			}
 		}

--- a/internal/views/views_test.go
+++ b/internal/views/views_test.go
@@ -27,13 +27,20 @@ func TestGetFilesByView_DefaultAndArchive(t *testing.T) {
 	mustWriteFile(t, trashedPath)
 
 	h := handler.NewFileHandler(vaultDir)
-	cfg := &config.Config{
+	ws := &config.Workspace{
 		VaultDir: vaultDir,
 		Views: map[string]config.ViewDefinition{
 			"custom": {
 				Exclude: []string{"archive", "trash", "notes/skip.md"},
 			},
 		},
+	}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
 	}
 
 	vm, err := NewViewManager(h, cfg)
@@ -110,13 +117,20 @@ func TestViewManagerOrderHonorsConfig(t *testing.T) {
 
 	vaultDir := t.TempDir()
 	h := handler.NewFileHandler(vaultDir)
-	cfg := &config.Config{
+	ws := &config.Workspace{
 		VaultDir: vaultDir,
 		Views: map[string]config.ViewDefinition{
 			"custom": {},
 			"beta":   {},
 		},
 		ViewOrder: []string{"custom", "beta"},
+	}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
 	}
 
 	vm, err := NewViewManager(h, cfg)

--- a/pkg/cmd/echo/echo.go
+++ b/pkg/cmd/echo/echo.go
@@ -117,27 +117,28 @@ func determineTargetPin(
 	auto bool,
 	c *config.Config,
 ) (string, string, error) {
+	ws := c.MustWorkspace()
 	if auto {
 		title, targetPin := generateFileName(c)
 		return title, targetPin, nil
 	}
 
 	if name != "" {
-		pin := c.NamedPins[name]
+		pin := ws.NamedPins[name]
 		if pin == "" {
 			return "", "", fmt.Errorf("no file pinned for the name '%s'", name)
 		}
 		return "", pin, nil
 	}
 
-	if c.PinnedFile == "" {
+	if ws.PinnedFile == "" {
 		return "", "", errors.New("no file pinned")
 	}
-	return "", c.PinnedFile, nil
+	return "", ws.PinnedFile, nil
 }
 
 func generateFileName(cfg *config.Config) (string, string) {
-	baseDir := filepath.Join(cfg.VaultDir, "echoes")
+	baseDir := filepath.Join(cfg.MustWorkspace().VaultDir, "echoes")
 
 	err := os.MkdirAll(baseDir, 0o755)
 	if err != nil {

--- a/pkg/cmd/journal/entry/entry_test.go
+++ b/pkg/cmd/journal/entry/entry_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/Paintersrp/an/internal/config"
 	"github.com/Paintersrp/an/internal/state"
 	"github.com/Paintersrp/an/internal/templater"
 	"github.com/Paintersrp/an/utils"
@@ -35,13 +36,26 @@ func setupEntryTest(t *testing.T) (*state.State, string) {
 
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	tmpl, err := templater.NewTemplater()
+	ws := &config.Workspace{VaultDir: vaultDir, Editor: "nvim"}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	tmpl, err := templater.NewTemplater(ws)
 	if err != nil {
 		t.Fatalf("failed to create templater: %v", err)
 	}
 
 	st := &state.State{
-		Templater: tmpl,
+		Config:        cfg,
+		Workspace:     ws,
+		WorkspaceName: "default",
+		Templater:     tmpl,
+		Vault:         vaultDir,
 	}
 
 	return st, vaultDir

--- a/pkg/cmd/open/openPin/openPin.go
+++ b/pkg/cmd/open/openPin/openPin.go
@@ -42,17 +42,18 @@ func run(cmd *cobra.Command, c *config.Config) error {
 		return err
 	}
 
+	ws := c.MustWorkspace()
 	var targetPin string
 	if name != "" {
-		if c.NamedPins[name] == "" {
+		if ws.NamedPins[name] == "" {
 			return fmt.Errorf("no pinned file found")
 		}
-		targetPin = c.NamedPins[name]
+		targetPin = ws.NamedPins[name]
 	} else {
-		if c.PinnedFile == "" {
+		if ws.PinnedFile == "" {
 			return errors.New("no pinned file found")
 		}
-		targetPin = c.PinnedFile
+		targetPin = ws.PinnedFile
 	}
 
 	if _, err := os.Stat(targetPin); os.IsNotExist(err) {

--- a/pkg/cmd/path_resolver.go
+++ b/pkg/cmd/path_resolver.go
@@ -13,7 +13,7 @@ func ResolveVaultPath(cmd *cobra.Command, s *state.State, arg string) (string, e
 	if s == nil || s.Config == nil {
 		return "", fmt.Errorf("state configuration is not initialized")
 	}
-	vaultDir := filepath.Clean(s.Config.VaultDir)
+	vaultDir := filepath.Clean(s.Config.MustWorkspace().VaultDir)
 	if vaultDir == "" {
 		return "", fmt.Errorf("vault directory is not configured")
 	}

--- a/pkg/cmd/path_resolver_test.go
+++ b/pkg/cmd/path_resolver_test.go
@@ -12,7 +12,16 @@ import (
 func TestResolveVaultPath(t *testing.T) {
 	vaultDir := t.TempDir()
 
-	st := &state.State{Config: &config.Config{VaultDir: vaultDir}}
+	cfg := &config.Config{
+		Workspaces: map[string]*config.Workspace{
+			"default": {VaultDir: vaultDir},
+		},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+	st := &state.State{Config: cfg, Workspace: cfg.MustWorkspace(), WorkspaceName: cfg.CurrentWorkspace}
 
 	tests := map[string]struct {
 		command *cobra.Command

--- a/pkg/cmd/pin/pinAdd/pinAdd.go
+++ b/pkg/cmd/pin/pinAdd/pinAdd.go
@@ -33,7 +33,12 @@ func NewCmdPinAdd(s *state.State, pinType string) *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if check {
-				fmt.Println("Current pinned file:", s.Config.PinnedFile)
+				ws := s.Config.MustWorkspace()
+				if pinType == "task" {
+					fmt.Println("Current pinned file:", ws.PinnedTaskFile)
+				} else {
+					fmt.Println("Current pinned file:", ws.PinnedFile)
+				}
 				return nil
 			}
 			return run(cmd, args, s, pinType)

--- a/pkg/cmd/pin/pinAdd/pinAdd_test.go
+++ b/pkg/cmd/pin/pinAdd/pinAdd_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Paintersrp/an/internal/config"
-	"github.com/Paintersrp/an/internal/pin"
 	"github.com/Paintersrp/an/internal/state"
 	"github.com/Paintersrp/an/pkg/shared/flags"
 )
@@ -22,16 +21,16 @@ func TestRunReturnsChangePinError(t *testing.T) {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
 
+	ws := &config.Workspace{NamedPins: config.PinMap{}, NamedTaskPins: config.PinMap{}}
 	cfg := &config.Config{
-		PinManager: pin.NewPinManager(
-			make(pin.PinMap),
-			make(pin.PinMap),
-			"",
-			"",
-		),
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
 	}
 
-	st := &state.State{Config: cfg}
+	st := &state.State{Config: cfg, Workspace: ws, WorkspaceName: "default"}
 
 	cmd := &cobra.Command{}
 	flags.AddPath(cmd)

--- a/pkg/cmd/pin/pinOpen/pinOpen.go
+++ b/pkg/cmd/pin/pinOpen/pinOpen.go
@@ -42,33 +42,34 @@ func run(cmd *cobra.Command, s *state.State, pinType string) error {
 		return err
 	}
 
+	ws := s.Config.MustWorkspace()
 	var targetPin string
 	if name != "" {
 		switch pinType {
 		case "text":
-			if s.Config.NamedPins[name] == "" {
+			if ws.NamedPins[name] == "" {
 				return fmt.Errorf("no pinned file found")
 			}
-			targetPin = s.Config.NamedPins[name]
+			targetPin = ws.NamedPins[name]
 		case "task":
-			if s.Config.NamedTaskPins[name] == "" {
+			if ws.NamedTaskPins[name] == "" {
 				return fmt.Errorf("no pinned file found")
 			}
-			targetPin = s.Config.NamedTaskPins[name]
+			targetPin = ws.NamedTaskPins[name]
 		}
 	} else {
 		switch pinType {
 		case "text":
-			if s.Config.PinnedFile == "" {
+			if ws.PinnedFile == "" {
 				return errors.New("no pinned file found")
 			}
-			targetPin = s.Config.PinnedFile
+			targetPin = ws.PinnedFile
 
 		case "task":
-			if s.Config.PinnedTaskFile == "" {
+			if ws.PinnedTaskFile == "" {
 				return errors.New("no pinned file found")
 			}
-			targetPin = s.Config.PinnedTaskFile
+			targetPin = ws.PinnedTaskFile
 		}
 	}
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Paintersrp/an/pkg/cmd/unarchive"
 	"github.com/Paintersrp/an/pkg/cmd/untrash"
 	"github.com/Paintersrp/an/pkg/cmd/views"
+	"github.com/Paintersrp/an/pkg/cmd/workspace"
 )
 
 var subdirName string
@@ -51,6 +52,18 @@ func NewCmdRoot(s *state.State) (*cobra.Command, error) {
 		)
 	viper.BindPFlag("subdir", cmd.PersistentFlags().Lookup("subdir"))
 
+	workspaceDefault := ""
+	if s != nil {
+		workspaceDefault = s.WorkspaceName
+	}
+	cmd.PersistentFlags().StringP(
+		"workspace",
+		"w",
+		workspaceDefault,
+		"Workspace to use for this invocation.",
+	)
+	viper.BindPFlag("workspace", cmd.PersistentFlags().Lookup("workspace"))
+
 	cmd.AddCommand(
 		initialize.NewCmdInit(s),
 		addSubdir.NewCmdAddSubdir(s),
@@ -70,6 +83,7 @@ func NewCmdRoot(s *state.State) (*cobra.Command, error) {
 		untrash.NewCmdUntrash(s),
 		journal.NewCmdJournal(s),
 		views.NewCmdViews(s),
+		workspace.NewCmdWorkspace(s),
 	)
 
 	return cmd, nil

--- a/pkg/cmd/tags/tags.go
+++ b/pkg/cmd/tags/tags.go
@@ -28,7 +28,7 @@ allowing for quick access and organization of notes by their associated tags.`,
 }
 
 func run(c *config.Config) error {
-	p := parser.NewParser(c.VaultDir)
+	p := parser.NewParser(c.MustWorkspace().VaultDir)
 
 	if err := p.Walk(); err != nil {
 		fmt.Println("Error:", err)

--- a/pkg/cmd/tasks/taskEcho/taskEcho.go
+++ b/pkg/cmd/tasks/taskEcho/taskEcho.go
@@ -48,22 +48,23 @@ func run(cmd *cobra.Command, args []string, s *state.State, priority string) err
 	task := strings.Join(args, " ")
 	taskEntry := fmt.Sprintf("- [ ] %s\n", task)
 
+	ws := s.Config.MustWorkspace()
 	var targetPin string
 	if name != "" {
-		if s.Config.NamedTaskPins[name] == "" {
+		if ws.NamedTaskPins[name] == "" {
 			return fmt.Errorf(
 				"no task file pinned for named task pin '%s'. Use the task-pin command to pin a task-file first",
 				name,
 			)
 		}
-		targetPin = s.Config.NamedTaskPins[name]
+		targetPin = ws.NamedTaskPins[name]
 	} else {
-		if s.Config.PinnedTaskFile == "" {
+		if ws.PinnedTaskFile == "" {
 			return errors.New(
 				"no task file pinned. Use the task-pin command to pin a task-file first",
 			)
 		}
-		targetPin = s.Config.PinnedTaskFile
+		targetPin = ws.PinnedTaskFile
 	}
 
 	content, err := os.ReadFile(targetPin)

--- a/pkg/cmd/tasks/taskEcho/taskEcho_test.go
+++ b/pkg/cmd/tasks/taskEcho/taskEcho_test.go
@@ -23,7 +23,16 @@ func TestRun_InvalidPriorityFallsBackToLow(t *testing.T) {
 		t.Fatalf("failed to write initial task file: %v", err)
 	}
 
-	st := &state.State{Config: &config.Config{PinnedTaskFile: taskFile}}
+	cfg := &config.Config{
+		Workspaces: map[string]*config.Workspace{
+			"default": {PinnedTaskFile: taskFile},
+		},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+	st := &state.State{Config: cfg, Workspace: cfg.MustWorkspace(), WorkspaceName: cfg.CurrentWorkspace}
 
 	cmd := &cobra.Command{}
 	cmd.Flags().StringP("name", "n", "", "")

--- a/pkg/cmd/tasks/taskOpenPin/taskOpenPin.go
+++ b/pkg/cmd/tasks/taskOpenPin/taskOpenPin.go
@@ -41,17 +41,18 @@ func run(cmd *cobra.Command, s *state.State) error {
 		return err
 	}
 
+	ws := s.Config.MustWorkspace()
 	var targetPin string
 	if name != "" {
-		if s.Config.NamedTaskPins[name] == "" {
+		if ws.NamedTaskPins[name] == "" {
 			return fmt.Errorf("no pinned task file found")
 		}
-		targetPin = s.Config.NamedTaskPins[name]
+		targetPin = ws.NamedTaskPins[name]
 	} else {
-		if s.Config.PinnedTaskFile == "" {
+		if ws.PinnedTaskFile == "" {
 			return errors.New("no pinned task file found")
 		}
-		targetPin = s.Config.PinnedTaskFile
+		targetPin = ws.PinnedTaskFile
 	}
 
 	if _, err := os.Stat(targetPin); os.IsNotExist(err) {

--- a/pkg/cmd/workspace/workspace.go
+++ b/pkg/cmd/workspace/workspace.go
@@ -1,0 +1,158 @@
+package workspace
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/state"
+)
+
+func NewCmdWorkspace(s *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workspace",
+		Short: "Manage workspaces",
+	}
+
+	cmd.AddCommand(
+		newCmdWorkspaceList(s),
+		newCmdWorkspaceSwitch(s),
+		newCmdWorkspaceAdd(s),
+		newCmdWorkspaceRemove(s),
+	)
+
+	return cmd
+}
+
+func newCmdWorkspaceList(s *state.State) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured workspaces",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			names := s.Config.WorkspaceNames()
+			if len(names) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No workspaces configured")
+				return nil
+			}
+
+			for _, name := range names {
+				marker := " "
+				if name == s.Config.CurrentWorkspace {
+					marker = "*"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", marker, name)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newCmdWorkspaceSwitch(s *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "switch [name]",
+		Short: "Switch the active workspace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := strings.TrimSpace(args[0])
+			if target == "" {
+				return fmt.Errorf("workspace name cannot be empty")
+			}
+
+			if err := s.Config.SwitchWorkspace(target); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Switched to workspace %q\n", target)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newCmdWorkspaceAdd(s *state.State) *cobra.Command {
+	var name string
+	var vault string
+	var makeCurrent bool
+
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a new workspace",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				return fmt.Errorf("workspace name is required")
+			}
+			vault = strings.TrimSpace(vault)
+			if vault == "" {
+				return fmt.Errorf("vault path is required")
+			}
+
+			template := cloneWorkspaceSettings(s.Workspace)
+			template.VaultDir = vault
+			ws := template
+
+			if err := s.Config.AddWorkspace(name, ws, makeCurrent); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Added workspace %q\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Name of the new workspace")
+	cmd.Flags().StringVar(&vault, "vault", "", "Path to the workspace vault")
+	cmd.Flags().BoolVar(&makeCurrent, "current", false, "Switch to the new workspace after creation")
+
+	return cmd
+}
+
+func newCmdWorkspaceRemove(s *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove [name]",
+		Short: "Remove an existing workspace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
+			if name == "" {
+				return fmt.Errorf("workspace name cannot be empty")
+			}
+
+			if err := s.Config.RemoveWorkspace(name); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Removed workspace %q\n", name)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func cloneWorkspaceSettings(src *config.Workspace) *config.Workspace {
+	if src == nil {
+		return &config.Workspace{}
+	}
+
+	clone := &config.Workspace{
+		Editor:         src.Editor,
+		NvimArgs:       src.NvimArgs,
+		FileSystemMode: src.FileSystemMode,
+		PinnedFile:     src.PinnedFile,
+		PinnedTaskFile: src.PinnedTaskFile,
+		SubDirs:        append([]string(nil), src.SubDirs...),
+		Search:         src.Search,
+		Views:          maps.Clone(src.Views),
+		ViewOrder:      append([]string(nil), src.ViewOrder...),
+	}
+	clone.Search.DefaultMetadataFilters = map[string][]string{}
+	for key, values := range src.Search.DefaultMetadataFilters {
+		clone.Search.DefaultMetadataFilters[key] = append([]string(nil), values...)
+	}
+	return clone
+}


### PR DESCRIPTION
## Summary
- restructure configuration to store named workspaces, migrate legacy configs, and expose helpers for switching, adding, and removing workspaces
- update state creation, templating, pin/task commands, and views to respect the active workspace and add a CLI workspace management suite
- expand tests to cover workspace persistence, path resolution, templating, and updated command behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d20a4fc7988325a424d5aa0a474c01