### PR TITLE
Add inline editor and scratch capture workflows to notes TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ an notes --view default
 
 When the Bubble Tea interface opens you will see a scrollable list of notes, a preview pane, and an on-demand help panel. Use <kbd>↑</kbd>/<kbd>↓</kbd> or <kbd>j</kbd>/<kbd>k</kbd> to move, <kbd>enter</kbd> to open the highlighted note in your editor, <kbd>tab</kbd> to toggle focus between the list and detail panel, and <kbd>?</kbd>/<kbd>h</kbd> to expand the full key binding cheat sheet. Common actions include <kbd>c</kbd> to create a note, <kbd>r</kbd> to rename, <kbd>y</kbd> to copy, <kbd>v</kbd> to switch views, and number keys <kbd>1</kbd>–<kbd>5</kbd> to jump between default, orphan, unfulfilled, archive, and trash views respectively.
 
+### Inline editing & captures
+
+Press <kbd>e</kbd> to open the highlighted note inside an inline editor without leaving the TUI. The textarea honours <kbd>ctrl+s</kbd> for save, <kbd>ctrl+r</kbd> to reload the on-disk version, and <kbd>esc</kbd> to discard changes (press twice to confirm if the buffer is dirty). External modifications are detected—when the backing file changes the editor warns and requires a second save to overwrite so you can reload the newer content instead.
+
+For quick captures, hit <kbd>q</kbd> to spawn a scratch buffer. Saving with <kbd>ctrl+s</kbd> writes the content into the first configured subdirectory (or the vault root when none is set) using a timestamped filename and refreshes the list so the new note is immediately available.
+
 Run `an --help` or any subcommand with `--help` to explore the rest of the command surface (journal, todo, settings, pin management, symlinks, etc.).
 
 ## Testing

--- a/internal/tui/notes/editor.go
+++ b/internal/tui/notes/editor.go
@@ -1,0 +1,116 @@
+package notes
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Paintersrp/an/internal/tui/textarea"
+)
+
+type editorMode int
+
+const (
+	editorModeNone editorMode = iota
+	editorModeExisting
+	editorModeScratch
+)
+
+type editorSession struct {
+	area             *textarea.Model
+	mode             editorMode
+	path             string
+	title            string
+	originalContent  string
+	originalChecksum [32]byte
+	originalModTime  time.Time
+	pendingDiscard   bool
+	allowOverwrite   bool
+	status           string
+}
+
+func newEditorSession(width, height int) *editorSession {
+	return &editorSession{area: textarea.New(width, height)}
+}
+
+func (s *editorSession) setMetadata(path, title string, mode editorMode) {
+	s.path = path
+	s.title = title
+	s.mode = mode
+}
+
+func (s *editorSession) setOriginal(content string, modTime time.Time) {
+	s.originalContent = content
+	s.originalChecksum = sha256.Sum256([]byte(content))
+	s.originalModTime = modTime
+	s.allowOverwrite = false
+	s.pendingDiscard = false
+}
+
+func (s *editorSession) hasChanges() bool {
+	if s == nil || s.area == nil {
+		return false
+	}
+	return s.area.Value() != s.originalContent
+}
+
+func (s *editorSession) viewHeader() string {
+	if s == nil {
+		return ""
+	}
+	switch s.mode {
+	case editorModeExisting:
+		return fmt.Sprintf("Editing %s", filepath.Base(s.title))
+	case editorModeScratch:
+		return "Scratch capture"
+	default:
+		return ""
+	}
+}
+
+func (s *editorSession) setSize(width, height int) {
+	if s == nil || s.area == nil {
+		return
+	}
+	s.area.SetSize(width, height)
+}
+
+func (s *editorSession) focus() tea.Cmd {
+	if s == nil || s.area == nil {
+		return nil
+	}
+	return s.area.Focus()
+}
+
+func (s *editorSession) blur() tea.Cmd {
+	if s == nil || s.area == nil {
+		return nil
+	}
+	return s.area.Blur()
+}
+
+func (s *editorSession) setValue(content string) {
+	if s == nil || s.area == nil {
+		return
+	}
+	s.area.SetValue(content)
+	s.pendingDiscard = false
+}
+
+func (s *editorSession) value() string {
+	if s == nil || s.area == nil {
+		return ""
+	}
+	return s.area.Value()
+}
+
+func (s *editorSession) checksumMatches(content []byte) bool {
+	if s == nil {
+		return true
+	}
+	sum := sha256.Sum256(content)
+	return sum == s.originalChecksum
+}

--- a/internal/tui/notes/editor_test.go
+++ b/internal/tui/notes/editor_test.go
@@ -1,0 +1,191 @@
+package notes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/handler"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/internal/views"
+)
+
+func newEditorTestModel(t *testing.T, files map[string]string) *NoteListModel {
+	t.Helper()
+
+	vault := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(vault, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed to create directory for %s: %v", name, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("failed to write note %s: %v", name, err)
+		}
+	}
+
+	captureDir := filepath.Join(vault, "captures")
+	if err := os.MkdirAll(captureDir, 0o755); err != nil {
+		t.Fatalf("failed to create capture directory: %v", err)
+	}
+
+	cfg := &config.Config{
+		Workspaces: map[string]*config.Workspace{
+			"default": {
+				VaultDir: vault,
+				Editor:   "nvim",
+				SubDirs:  []string{"captures"},
+			},
+		},
+		CurrentWorkspace: "default",
+	}
+
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	fileHandler := handler.NewFileHandler(vault)
+	viewManager, err := views.NewViewManager(fileHandler, cfg)
+	if err != nil {
+		t.Fatalf("failed to create view manager: %v", err)
+	}
+
+	st := &state.State{
+		Config:        cfg,
+		Workspace:     cfg.MustWorkspace(),
+		WorkspaceName: "default",
+		Handler:       fileHandler,
+		ViewManager:   viewManager,
+		Vault:         vault,
+	}
+
+	model, err := NewNoteListModel(st, "default")
+	if err != nil {
+		t.Fatalf("failed to create note list model: %v", err)
+	}
+
+	model.width = 100
+	model.height = 40
+	model.list.SetShowStatusBar(false)
+	if len(model.list.Items()) > 0 {
+		model.list.Select(0)
+	}
+
+	return model
+}
+
+func TestStartInlineEditLoadsContent(t *testing.T) {
+	model := newEditorTestModel(t, map[string]string{"note.md": "original content"})
+
+	_ = model.startInlineEdit()
+
+	if model.editor == nil {
+		t.Fatalf("expected editor session to be active")
+	}
+
+	if got := model.editor.value(); got != "original content" {
+		t.Fatalf("unexpected editor contents: %q", got)
+	}
+}
+
+func TestSaveExistingEditorDetectsConflict(t *testing.T) {
+	model := newEditorTestModel(t, map[string]string{"note.md": "original"})
+	_ = model.startInlineEdit()
+
+	if model.editor == nil {
+		t.Fatalf("expected editor session to be active")
+	}
+
+	path := model.editor.path
+	model.editor.setValue("updated")
+
+	time.Sleep(time.Second)
+	if err := os.WriteFile(path, []byte("external"), 0o644); err != nil {
+		t.Fatalf("failed to write external change: %v", err)
+	}
+
+	_ = model.saveEditor()
+
+	if model.editor == nil {
+		t.Fatalf("expected editor to remain open after conflict")
+	}
+
+	if !model.editor.allowOverwrite {
+		t.Fatalf("expected allowOverwrite flag to be set")
+	}
+
+	if !strings.Contains(model.editor.status, "External changes") {
+		t.Fatalf("expected conflict status message, got %q", model.editor.status)
+	}
+}
+
+func TestSaveExistingEditorWritesFile(t *testing.T) {
+	model := newEditorTestModel(t, map[string]string{"note.md": "original"})
+	_ = model.startInlineEdit()
+
+	path := model.editor.path
+	model.editor.setValue("updated")
+
+	_ = model.saveEditor()
+
+	if model.editor != nil {
+		t.Fatalf("expected editor session to close after save")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read note after save: %v", err)
+	}
+
+	if string(data) != "updated" {
+		t.Fatalf("expected file to contain updated content, got %q", string(data))
+	}
+}
+
+func TestSaveExistingEditorHandlesWriteError(t *testing.T) {
+	model := newEditorTestModel(t, map[string]string{"note.md": "original"})
+	_ = model.startInlineEdit()
+
+	model.editor.setValue("updated")
+	model.state.Handler = nil
+
+	_ = model.saveEditor()
+
+	if model.editor == nil {
+		t.Fatalf("expected editor to remain open after error")
+	}
+
+	if !strings.Contains(model.editor.status, "File handler unavailable") {
+		t.Fatalf("expected handler error message, got %q", model.editor.status)
+	}
+}
+
+func TestQuickCaptureCreatesFile(t *testing.T) {
+	model := newEditorTestModel(t, map[string]string{})
+	_ = model.startScratchCapture()
+
+	if model.editor == nil {
+		t.Fatalf("expected scratch editor to be active")
+	}
+
+	path := model.editor.path
+	model.editor.setValue("scratch body")
+
+	_ = model.saveEditor()
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected scratch file to exist: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read scratch file: %v", err)
+	}
+
+	if string(data) != "scratch body" {
+		t.Fatalf("unexpected scratch file contents: %q", string(data))
+	}
+}

--- a/internal/tui/notes/keys.go
+++ b/internal/tui/notes/keys.go
@@ -3,22 +3,24 @@ package notes
 import "github.com/charmbracelet/bubbles/key"
 
 type listKeyMap struct {
-	toggleTitleBar        key.Binding
-	toggleStatusBar       key.Binding
-	togglePagination      key.Binding
-	toggleHelpMenu        key.Binding
-	openNote              key.Binding
-	toggleFocus           key.Binding
-	quit                  key.Binding
-	changeView            key.Binding
-	rename                key.Binding
-	create                key.Binding
-	copy                  key.Binding
-	link                  key.Binding
-	submitAltView         key.Binding
-	exitAltView           key.Binding
-	toggleDisplayView     key.Binding
-	switchToDefaultView   key.Binding
+        toggleTitleBar        key.Binding
+        toggleStatusBar       key.Binding
+        togglePagination      key.Binding
+        toggleHelpMenu        key.Binding
+        openNote              key.Binding
+        toggleFocus           key.Binding
+        quit                  key.Binding
+        changeView            key.Binding
+        rename                key.Binding
+        create                key.Binding
+        copy                  key.Binding
+        editInline           key.Binding
+        quickCapture         key.Binding
+        link                  key.Binding
+        submitAltView         key.Binding
+        exitAltView           key.Binding
+        toggleDisplayView     key.Binding
+        switchToDefaultView   key.Binding
 	switchToArchiveView   key.Binding
 	switchToOrphanView    key.Binding
 	switchToTrashView     key.Binding
@@ -74,14 +76,22 @@ func newListKeyMap() *listKeyMap {
 			key.WithKeys("C"),
 			key.WithHelp("C", "create"),
 		),
-		copy: key.NewBinding(
-			key.WithKeys("Y"),
-			key.WithHelp("Y", "copy"),
-		),
-		submitAltView: key.NewBinding(
-			key.WithKeys("enter"),
-			key.WithHelp("↵", "submit (alt view)"),
-		),
+                copy: key.NewBinding(
+                        key.WithKeys("Y"),
+                        key.WithHelp("Y", "copy"),
+                ),
+                editInline: key.NewBinding(
+                        key.WithKeys("E"),
+                        key.WithHelp("E", "inline edit"),
+                ),
+                quickCapture: key.NewBinding(
+                        key.WithKeys("Q"),
+                        key.WithHelp("Q", "scratch capture"),
+                ),
+                submitAltView: key.NewBinding(
+                        key.WithKeys("enter"),
+                        key.WithHelp("↵", "submit (alt view)"),
+                ),
 		exitAltView: key.NewBinding(
 			key.WithKeys("esc"),
 			key.WithHelp("esc", "exit alt view"),
@@ -139,10 +149,12 @@ func (m listKeyMap) fullHelp() []key.Binding {
 		m.toggleStatusBar,
 		m.togglePagination,
 		m.toggleHelpMenu,
-		m.toggleDisplayView,
-		m.openNote,
-		m.rename,
-		m.copy,
+                m.toggleDisplayView,
+                m.openNote,
+                m.editInline,
+                m.quickCapture,
+                m.rename,
+                m.copy,
 		m.changeView,
 		m.switchToDefaultView,
 		m.switchToArchiveView,


### PR DESCRIPTION
## Summary
- integrate a reusable textarea wrapper and embed it into the note list as an inline editor with save/discard shortcuts and scratch capture mode
- add handler helpers for safe vault reads/writes, update key bindings, conflict handling, and preview refresh logic when saving
- document the new shortcuts and add tests covering inline edit toggles, conflict detection, save errors, and quick capture flows

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d210494d54832598cb8c2d03b64caa