### PR TITLE
Add shared task and journal services with TUI integration

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -18,6 +18,13 @@ func NewFileHandler(vaultDir string) *FileHandler {
 	return &FileHandler{vaultDir: vaultDir}
 }
 
+func (h *FileHandler) VaultDir() string {
+	if h == nil {
+		return ""
+	}
+	return h.vaultDir
+}
+
 func (h *FileHandler) resolve(path string) (string, error) {
 	if h == nil {
 		return "", fmt.Errorf("file handler is not configured")

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -67,10 +67,27 @@ tags:
 
 func TestTaskHandlerParseTaskIgnoresEmptyContent(t *testing.T) {
 	handler := NewTaskHandler()
-	handler.ParseTask("[ ]   ")
+	handler.ParseTask("[ ]   ", "", 0)
 
 	if len(handler.Tasks) != 0 {
 		t.Fatalf("expected no tasks to be added for empty content, got %#v", handler.Tasks)
+	}
+}
+
+func TestTaskHandlerRecordsPathAndLine(t *testing.T) {
+	handler := NewTaskHandler()
+	handler.ParseTask("[ ] example", "/tmp/note.md", 42)
+
+	if len(handler.Tasks) != 1 {
+		t.Fatalf("expected a single task to be recorded, got %d", len(handler.Tasks))
+	}
+
+	task := handler.Tasks[1]
+	if task.Path != "/tmp/note.md" {
+		t.Fatalf("expected path to be recorded, got %q", task.Path)
+	}
+	if task.Line != 42 {
+		t.Fatalf("expected line number 42, got %d", task.Line)
 	}
 }
 

--- a/internal/parser/tasks.go
+++ b/internal/parser/tasks.go
@@ -16,6 +16,8 @@ type Task struct {
 	Status  string
 	Content string
 	ID      int
+	Path    string
+	Line    int
 }
 
 type TaskHandler struct {
@@ -30,22 +32,24 @@ func NewTaskHandler() *TaskHandler {
 	}
 }
 
-func (th *TaskHandler) ParseTask(content string) {
+func (th *TaskHandler) ParseTask(content, path string, line int) {
 	if (strings.HasPrefix(content, "[ ]") || strings.HasPrefix(content, "[x]")) &&
 		len(strings.TrimSpace(content[3:])) > 0 {
 		status := "unchecked"
 		if strings.HasPrefix(content, "[x]") {
 			status = "checked"
 		}
-		th.AddTask(status, strings.TrimSpace(content[3:]))
+		th.AddTask(status, strings.TrimSpace(content[3:]), path, line)
 	}
 }
 
-func (th *TaskHandler) AddTask(status, content string) {
+func (th *TaskHandler) AddTask(status, content, path string, line int) {
 	th.Tasks[th.NextID] = Task{
 		ID:      th.NextID,
 		Status:  status,
 		Content: content,
+		Path:    path,
+		Line:    line,
 	}
 	th.NextID++
 }

--- a/internal/services/journal/service.go
+++ b/internal/services/journal/service.go
@@ -1,0 +1,153 @@
+package journal
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Paintersrp/an/internal/handler"
+	"github.com/Paintersrp/an/internal/note"
+	"github.com/Paintersrp/an/internal/templater"
+	"github.com/Paintersrp/an/utils"
+)
+
+type Entry struct {
+	Template string
+	Path     string
+	Title    string
+	Date     time.Time
+}
+
+type Service struct {
+	templater *templater.Templater
+	handler   *handler.FileHandler
+	openFunc  func(string, bool) error
+}
+
+func NewService(t *templater.Templater, h *handler.FileHandler) *Service {
+	return &Service{
+		templater: t,
+		handler:   h,
+		openFunc:  note.OpenFromPath,
+	}
+}
+
+func (s *Service) EnsureEntry(templateType string, index int, tags, links []string, content string) (Entry, error) {
+	if s == nil || s.templater == nil || s.handler == nil {
+		return Entry{}, errors.New("journal service is not configured")
+	}
+
+	vault := s.handler.VaultDir()
+	date := utils.GenerateDate(index, templateType)
+	filename := fmt.Sprintf("%s-%s", templateType, date)
+
+	n := note.NewZettelkastenNote(
+		vault,
+		"atoms",
+		filename,
+		tags,
+		links,
+		"",
+	)
+
+	exists, path, err := n.FileExists()
+	if err != nil {
+		return Entry{}, err
+	}
+
+	if !exists {
+		if _, err := n.Create(templateType, s.templater, content); err != nil {
+			return Entry{}, err
+		}
+		path = n.GetFilepath()
+	}
+
+	entry := Entry{
+		Template: templateType,
+		Path:     path,
+		Title:    filename,
+		Date:     parseDate(templateType, date),
+	}
+	return entry, nil
+}
+
+func (s *Service) Open(path string) error {
+	if s == nil {
+		return errors.New("journal service is not configured")
+	}
+	return s.openFunc(path, false)
+}
+
+func (s *Service) List(templateType string) ([]Entry, error) {
+	if s == nil || s.handler == nil {
+		return nil, errors.New("journal service is not configured")
+	}
+
+	vault := s.handler.VaultDir()
+	root := filepath.Join(vault, "atoms")
+	pattern := templateType + "-"
+
+	entries := make([]Entry, 0)
+	walkFn := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(d.Name()) != ".md" {
+			return nil
+		}
+		name := strings.TrimSuffix(d.Name(), ".md")
+		if !strings.HasPrefix(name, pattern) {
+			return nil
+		}
+
+		suffix := strings.TrimPrefix(name, pattern)
+		entry := Entry{
+			Template: templateType,
+			Path:     path,
+			Title:    name,
+			Date:     parseDate(templateType, suffix),
+		}
+		entries = append(entries, entry)
+		return nil
+	}
+
+	if err := filepath.WalkDir(root, walkFn); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return []Entry{}, nil
+		}
+		return nil, err
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Date.After(entries[j].Date)
+	})
+
+	return entries, nil
+}
+
+func parseDate(templateType, value string) time.Time {
+	formats := map[string]string{
+		"day":   "20060102",
+		"week":  "20060102",
+		"month": "200601",
+		"year":  "2006",
+	}
+
+	format, ok := formats[templateType]
+	if !ok {
+		format = "20060102"
+	}
+
+	parsed, err := time.Parse(format, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}

--- a/internal/services/journal/service_test.go
+++ b/internal/services/journal/service_test.go
@@ -1,0 +1,69 @@
+package journal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/handler"
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+func newTemplater(t *testing.T, dir string) *templater.Templater {
+	t.Helper()
+	ws := &config.Workspace{VaultDir: dir}
+	tmpl, err := templater.NewTemplater(ws)
+	if err != nil {
+		t.Fatalf("failed to create templater: %v", err)
+	}
+	return tmpl
+}
+
+func TestEnsureEntryCreatesNote(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewService(newTemplater(t, dir), handler.NewFileHandler(dir))
+
+	entry, err := svc.EnsureEntry("day", 0, []string{"tag"}, nil, "body")
+	if err != nil {
+		t.Fatalf("EnsureEntry returned error: %v", err)
+	}
+
+	if entry.Path == "" {
+		t.Fatalf("expected entry path to be populated")
+	}
+	if _, err := os.Stat(entry.Path); err != nil {
+		t.Fatalf("expected journal entry file to exist: %v", err)
+	}
+}
+
+func TestListReturnsSortedEntries(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewService(newTemplater(t, dir), handler.NewFileHandler(dir))
+
+	now := time.Now()
+	for i := 0; i < 3; i++ {
+		date := now.AddDate(0, 0, -i).Format("20060102")
+		name := filepath.Join(dir, "atoms", "day-"+date+".md")
+		if err := os.MkdirAll(filepath.Dir(name), 0o755); err != nil {
+			t.Fatalf("failed to create dir: %v", err)
+		}
+		if err := os.WriteFile(name, []byte("content"), 0o644); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+	}
+
+	entries, err := svc.List("day")
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+
+	if len(entries) != 3 {
+		t.Fatalf("expected three entries, got %d", len(entries))
+	}
+
+	if entries[0].Date.Before(entries[1].Date) {
+		t.Fatalf("expected entries to be sorted descending by date")
+	}
+}

--- a/internal/services/tasks/service.go
+++ b/internal/services/tasks/service.go
@@ -1,0 +1,141 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/table"
+
+	"github.com/Paintersrp/an/internal/handler"
+	"github.com/Paintersrp/an/internal/note"
+	"github.com/Paintersrp/an/internal/parser"
+)
+
+type Item struct {
+	ID        int
+	Content   string
+	Completed bool
+	Path      string
+	Line      int
+	RelPath   string
+}
+
+type Service struct {
+	handler       *handler.FileHandler
+	parserFactory func(string) *parser.Parser
+	openFunc      func(string, bool) error
+}
+
+func NewService(h *handler.FileHandler) *Service {
+	return &Service{
+		handler:       h,
+		parserFactory: parser.NewParser,
+		openFunc:      note.OpenFromPath,
+	}
+}
+
+func (s *Service) List() ([]Item, error) {
+	if s == nil || s.handler == nil {
+		return nil, errors.New("task service is not configured")
+	}
+
+	vault := s.handler.VaultDir()
+	p := s.parserFactory(vault)
+	if err := p.Walk(); err != nil {
+		return nil, err
+	}
+
+	items := make([]Item, 0, len(p.TaskHandler.Tasks))
+	for _, task := range p.TaskHandler.Tasks {
+		rel := task.Path
+		if relPath, err := filepath.Rel(vault, task.Path); err == nil {
+			rel = filepath.ToSlash(relPath)
+		}
+
+		items = append(items, Item{
+			ID:        task.ID,
+			Content:   task.Content,
+			Completed: strings.EqualFold(task.Status, "checked"),
+			Path:      task.Path,
+			Line:      task.Line,
+			RelPath:   rel,
+		})
+	}
+
+	return items, nil
+}
+
+func (s *Service) Toggle(path string, line int) (bool, error) {
+	if s == nil || s.handler == nil {
+		return false, errors.New("task service is not configured")
+	}
+
+	data, err := s.handler.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	if line <= 0 || line > len(lines) {
+		return false, fmt.Errorf("line %d out of range", line)
+	}
+
+	target := lines[line-1]
+	switch {
+	case strings.Contains(target, "[ ]"):
+		idx := strings.Index(target, "[ ]")
+		lines[line-1] = target[:idx] + strings.Replace(target[idx:], "[ ]", "[x]", 1)
+		if err := s.handler.WriteFile(path, []byte(strings.Join(lines, "\n"))); err != nil {
+			return false, err
+		}
+		return true, nil
+	case strings.Contains(target, "[x]"):
+		idx := strings.Index(target, "[x]")
+		lines[line-1] = target[:idx] + strings.Replace(target[idx:], "[x]", "[ ]", 1)
+		if err := s.handler.WriteFile(path, []byte(strings.Join(lines, "\n"))); err != nil {
+			return false, err
+		}
+		return false, nil
+	default:
+		return false, fmt.Errorf("no markdown task found on line %d", line)
+	}
+}
+
+func (s *Service) Open(path string) error {
+	if s == nil {
+		return errors.New("task service is not configured")
+	}
+	return s.openFunc(path, false)
+}
+
+func TableFromItems(items []Item, height int) table.Model {
+	columns := []table.Column{
+		{Title: "ID", Width: 4},
+		{Title: "Status", Width: 10},
+		{Title: "Content", Width: 60},
+		{Title: "Path", Width: 40},
+	}
+
+	rows := make([]table.Row, 0, len(items))
+	for _, item := range items {
+		status := "unchecked"
+		if item.Completed {
+			status = "checked"
+		}
+		rows = append(rows, table.Row{
+			fmt.Sprintf("%d", item.ID),
+			status,
+			item.Content,
+			item.RelPath,
+		})
+	}
+
+	return table.New(
+		table.WithColumns(columns),
+		table.WithRows(rows),
+		table.WithFocused(true),
+		table.WithHeight(height),
+	)
+}

--- a/internal/services/tasks/service_test.go
+++ b/internal/services/tasks/service_test.go
@@ -1,0 +1,70 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/handler"
+)
+
+func TestServiceListIncludesPathAndStatus(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "atoms", "example.md")
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+
+	content := "- [ ] first task\n- [x] done task\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	svc := NewService(handler.NewFileHandler(dir))
+	tasks, err := svc.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+
+	if len(tasks) != 2 {
+		t.Fatalf("expected two tasks, got %d", len(tasks))
+	}
+
+	if tasks[0].Path == "" || tasks[0].Line == 0 {
+		t.Fatalf("expected task metadata to include path and line, got %#v", tasks[0])
+	}
+
+	if tasks[1].Completed != true {
+		t.Fatalf("expected completed task to be marked complete")
+	}
+}
+
+func TestServiceToggleFlipsCompletion(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "atoms", "example.md")
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+
+	content := "- [ ] first task\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	svc := NewService(handler.NewFileHandler(dir))
+	completed, err := svc.Toggle(file, 1)
+	if err != nil {
+		t.Fatalf("Toggle returned error: %v", err)
+	}
+	if !completed {
+		t.Fatalf("expected task to be marked complete after toggle")
+	}
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if string(data) != "- [x] first task\n" {
+		t.Fatalf("expected task to be toggled, got %q", string(data))
+	}
+}

--- a/internal/tui/journal/model.go
+++ b/internal/tui/journal/model.go
@@ -1,0 +1,209 @@
+package journal
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+
+	svc "github.com/Paintersrp/an/internal/services/journal"
+	"github.com/Paintersrp/an/internal/state"
+)
+
+type Model struct {
+	service *svc.Service
+	state   *state.State
+	list    list.Model
+	keys    keyMap
+	active  string
+	status  string
+	width   int
+	height  int
+}
+
+type keyMap struct {
+	open    key.Binding
+	today   key.Binding
+	refresh key.Binding
+	day     key.Binding
+	week    key.Binding
+	month   key.Binding
+	year    key.Binding
+}
+
+type entryItem struct {
+	entry svc.Entry
+}
+
+func NewModel(s *state.State) (*Model, error) {
+	if s == nil || s.Handler == nil || s.Templater == nil {
+		return nil, fmt.Errorf("journal model requires configured state dependencies")
+	}
+
+	service := svc.NewService(s.Templater, s.Handler)
+	entries, err := service.List("day")
+	if err != nil {
+		return nil, err
+	}
+
+	delegate := list.NewDefaultDelegate()
+	lm := list.New(toListItems(entries), delegate, 0, 0)
+	lm.Title = "Day Journal"
+	lm.DisableQuitKeybindings()
+
+	return &Model{
+		service: service,
+		state:   s,
+		list:    lm,
+		keys:    newKeyMap(),
+		active:  "day",
+	}, nil
+}
+
+func newKeyMap() keyMap {
+	return keyMap{
+		open: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("↵", "open"),
+		),
+		today: key.NewBinding(
+			key.WithKeys("t"),
+			key.WithHelp("t", "today"),
+		),
+		refresh: key.NewBinding(
+			key.WithKeys("ctrl+r"),
+			key.WithHelp("ctrl+r", "refresh"),
+		),
+		day: key.NewBinding(
+			key.WithKeys("1"),
+			key.WithHelp("1", "day"),
+		),
+		week: key.NewBinding(
+			key.WithKeys("2"),
+			key.WithHelp("2", "week"),
+		),
+		month: key.NewBinding(
+			key.WithKeys("3"),
+			key.WithHelp("3", "month"),
+		),
+		year: key.NewBinding(
+			key.WithKeys("4"),
+			key.WithHelp("4", "year"),
+		),
+	}
+}
+
+func toListItems(entries []svc.Entry) []list.Item {
+	items := make([]list.Item, 0, len(entries))
+	for _, entry := range entries {
+		items = append(items, entryItem{entry: entry})
+	}
+	return items
+}
+
+func (i entryItem) Title() string {
+	if i.entry.Date.IsZero() {
+		return strings.Title(i.entry.Title)
+	}
+	return fmt.Sprintf("%s", i.entry.Title)
+}
+
+func (i entryItem) Description() string {
+	if i.entry.Date.IsZero() {
+		return i.entry.Path
+	}
+	return fmt.Sprintf("%s", i.entry.Date.Format("2006-01-02"))
+}
+
+func (i entryItem) FilterValue() string {
+	return i.entry.Title
+}
+
+func (m *Model) Init() tea.Cmd { return nil }
+
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.list.SetSize(msg.Width, msg.Height-2)
+		return m, nil
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.keys.open):
+			return m.handleOpen()
+		case key.Matches(msg, m.keys.today):
+			return m.handleToday()
+		case key.Matches(msg, m.keys.refresh):
+			return m, m.refresh()
+		case key.Matches(msg, m.keys.day):
+			return m.switchTemplate("day")
+		case key.Matches(msg, m.keys.week):
+			return m.switchTemplate("week")
+		case key.Matches(msg, m.keys.month):
+			return m.switchTemplate("month")
+		case key.Matches(msg, m.keys.year):
+			return m.switchTemplate("year")
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m *Model) View() string {
+	if m.status != "" {
+		return fmt.Sprintf("%s\n%s", m.list.View(), m.status)
+	}
+	return m.list.View()
+}
+
+func (m *Model) switchTemplate(template string) (tea.Model, tea.Cmd) {
+	if m.active == template {
+		return m, nil
+	}
+	m.active = template
+	title := strings.Title(template) + " Journal"
+	m.list.Title = title
+	return m, m.refresh()
+}
+
+func (m *Model) refresh() tea.Cmd {
+	entries, err := m.service.List(m.active)
+	if err != nil {
+		m.status = fmt.Sprintf("refresh failed: %v", err)
+		return nil
+	}
+	m.status = fmt.Sprintf("showing %s entries", m.active)
+	return m.list.SetItems(toListItems(entries))
+}
+
+func (m *Model) handleOpen() (tea.Model, tea.Cmd) {
+	item, ok := m.list.SelectedItem().(entryItem)
+	if !ok {
+		return m, nil
+	}
+	if err := m.service.Open(item.entry.Path); err != nil {
+		m.status = fmt.Sprintf("open failed: %v", err)
+	} else {
+		m.status = fmt.Sprintf("opened %s", item.entry.Title)
+	}
+	return m, nil
+}
+
+func (m *Model) handleToday() (tea.Model, tea.Cmd) {
+	entry, err := m.service.EnsureEntry(m.active, 0, nil, nil, "")
+	if err != nil {
+		m.status = fmt.Sprintf("ensure failed: %v", err)
+		return m, nil
+	}
+	if err := m.service.Open(entry.Path); err != nil {
+		m.status = fmt.Sprintf("open failed: %v", err)
+		return m, nil
+	}
+	m.status = fmt.Sprintf("opened %s", entry.Title)
+	return m, m.refresh()
+}

--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -22,7 +22,9 @@ import (
 	"github.com/Paintersrp/an/internal/pathutil"
 	"github.com/Paintersrp/an/internal/search"
 	"github.com/Paintersrp/an/internal/state"
+	journaltui "github.com/Paintersrp/an/internal/tui/journal"
 	"github.com/Paintersrp/an/internal/tui/notes/submodels"
+	taskstui "github.com/Paintersrp/an/internal/tui/tasks"
 	v "github.com/Paintersrp/an/internal/views"
 	"github.com/Paintersrp/an/utils"
 )
@@ -978,12 +980,24 @@ func Run(s *state.State, views map[string]v.View, viewFlag string) error {
 		}
 	}()
 
-	m, err := NewNoteListModel(s, viewFlag)
+	noteModel, err := NewNoteListModel(s, viewFlag)
 	if err != nil {
 		return err
 	}
 
-	if _, err := tea.NewProgram(m, tea.WithInput(os.Stdin), tea.WithAltScreen()).Run(); err != nil {
+	tasksModel, err := taskstui.NewModel(s)
+	if err != nil {
+		return err
+	}
+
+	journalModel, err := journaltui.NewModel(s)
+	if err != nil {
+		return err
+	}
+
+	root := NewRootModel(noteModel, tasksModel, journalModel)
+
+	if _, err := tea.NewProgram(root, tea.WithInput(os.Stdin), tea.WithAltScreen()).Run(); err != nil {
 		// handle error for instances where neovim/editor doesn't pass stdin back in time to close gracefully with bubbletea
 		if strings.Contains(err.Error(), "resource temporarily unavailable") {
 			os.Exit(0)

--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -1,0 +1,205 @@
+package notes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+
+	journaltui "github.com/Paintersrp/an/internal/tui/journal"
+	taskstui "github.com/Paintersrp/an/internal/tui/tasks"
+)
+
+type rootView string
+
+const (
+	viewNotes   rootView = "notes"
+	viewTasks   rootView = "tasks"
+	viewJournal rootView = "journal"
+)
+
+type RootModel struct {
+	notes   *NoteListModel
+	tasks   *taskstui.Model
+	journal *journaltui.Model
+	active  rootView
+	keys    rootKeyMap
+}
+
+type rootKeyMap struct {
+	notes   key.Binding
+	tasks   key.Binding
+	journal key.Binding
+}
+
+func newRootKeyMap() rootKeyMap {
+	return rootKeyMap{
+		notes: key.NewBinding(
+			key.WithKeys("1"),
+			key.WithHelp("1", "notes"),
+		),
+		tasks: key.NewBinding(
+			key.WithKeys("2"),
+			key.WithHelp("2", "tasks"),
+		),
+		journal: key.NewBinding(
+			key.WithKeys("3"),
+			key.WithHelp("3", "journal"),
+		),
+	}
+}
+
+func NewRootModel(notes *NoteListModel, tasks *taskstui.Model, journal *journaltui.Model) *RootModel {
+	return &RootModel{
+		notes:   notes,
+		tasks:   tasks,
+		journal: journal,
+		active:  viewNotes,
+		keys:    newRootKeyMap(),
+	}
+}
+
+func (m *RootModel) Init() tea.Cmd {
+	cmds := []tea.Cmd{}
+	if m.notes != nil {
+		cmds = append(cmds, m.notes.Init())
+	}
+	if m.tasks != nil {
+		cmds = append(cmds, m.tasks.Init())
+	}
+	if m.journal != nil {
+		cmds = append(cmds, m.journal.Init())
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m *RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.updateAll(msg)
+		return m, nil
+	case tea.QuitMsg:
+		if m.notes != nil {
+			model, _ := m.notes.Update(msg)
+			m.notes = adoptNoteModel(model, m.notes)
+		}
+		return m, nil
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.keys.notes):
+			m.active = viewNotes
+			return m, nil
+		case key.Matches(msg, m.keys.tasks):
+			m.active = viewTasks
+			return m, nil
+		case key.Matches(msg, m.keys.journal):
+			m.active = viewJournal
+			return m, nil
+		}
+	}
+
+	switch m.active {
+	case viewNotes:
+		if m.notes == nil {
+			return m, nil
+		}
+		model, cmd := m.notes.Update(msg)
+		m.notes = adoptNoteModel(model, m.notes)
+		return m, cmd
+	case viewTasks:
+		if m.tasks == nil {
+			return m, nil
+		}
+		model, cmd := m.tasks.Update(msg)
+		m.tasks = adoptTasksModel(model, m.tasks)
+		return m, cmd
+	case viewJournal:
+		if m.journal == nil {
+			return m, nil
+		}
+		model, cmd := m.journal.Update(msg)
+		m.journal = adoptJournalModel(model, m.journal)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m *RootModel) View() string {
+	sections := []string{
+		m.header(),
+	}
+
+	switch m.active {
+	case viewNotes:
+		if m.notes != nil {
+			sections = append(sections, m.notes.View())
+		}
+	case viewTasks:
+		if m.tasks != nil {
+			sections = append(sections, m.tasks.View())
+		}
+	case viewJournal:
+		if m.journal != nil {
+			sections = append(sections, m.journal.View())
+		}
+	}
+
+	return strings.Join(sections, "\n")
+}
+
+func (m *RootModel) header() string {
+	sections := []string{"Views:"}
+	sections = append(sections, highlight(viewNotes, m.active, "1. Notes"))
+	sections = append(sections, highlight(viewTasks, m.active, "2. Tasks"))
+	sections = append(sections, highlight(viewJournal, m.active, "3. Journal"))
+	return strings.Join(sections, "  ")
+}
+
+func highlight(view rootView, active rootView, label string) string {
+	if view == active {
+		return fmt.Sprintf("[%s]", label)
+	}
+	return label
+}
+
+func (m *RootModel) updateAll(msg tea.Msg) {
+	if m.notes != nil {
+		model, _ := m.notes.Update(msg)
+		m.notes = adoptNoteModel(model, m.notes)
+	}
+	if m.tasks != nil {
+		model, _ := m.tasks.Update(msg)
+		m.tasks = adoptTasksModel(model, m.tasks)
+	}
+	if m.journal != nil {
+		model, _ := m.journal.Update(msg)
+		m.journal = adoptJournalModel(model, m.journal)
+	}
+}
+
+func adoptNoteModel(model tea.Model, current *NoteListModel) *NoteListModel {
+	switch m := model.(type) {
+	case *NoteListModel:
+		return m
+	case NoteListModel:
+		return &m
+	default:
+		return current
+	}
+}
+
+func adoptTasksModel(model tea.Model, current *taskstui.Model) *taskstui.Model {
+	if m, ok := model.(*taskstui.Model); ok {
+		return m
+	}
+	return current
+}
+
+func adoptJournalModel(model tea.Model, current *journaltui.Model) *journaltui.Model {
+	if m, ok := model.(*journaltui.Model); ok {
+		return m
+	}
+	return current
+}

--- a/internal/tui/notes/root_test.go
+++ b/internal/tui/notes/root_test.go
@@ -1,0 +1,112 @@
+package notes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/handler"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/internal/templater"
+	journaltui "github.com/Paintersrp/an/internal/tui/journal"
+	taskstui "github.com/Paintersrp/an/internal/tui/tasks"
+	"github.com/Paintersrp/an/internal/views"
+)
+
+func TestRootModelNavigation(t *testing.T) {
+	dir := t.TempDir()
+	atoms := filepath.Join(dir, "atoms")
+	if err := os.MkdirAll(atoms, 0o755); err != nil {
+		t.Fatalf("failed to create atoms directory: %v", err)
+	}
+
+	notePath := filepath.Join(atoms, "note.md")
+	if err := os.WriteFile(notePath, []byte("---\ntitle: test\n---\n"), 0o644); err != nil {
+		t.Fatalf("failed to write note: %v", err)
+	}
+
+	tasksPath := filepath.Join(atoms, "tasks.md")
+	if err := os.WriteFile(tasksPath, []byte("- [ ] task"), 0o644); err != nil {
+		t.Fatalf("failed to write tasks file: %v", err)
+	}
+
+	journalPath := filepath.Join(atoms, "day-20240101.md")
+	if err := os.WriteFile(journalPath, []byte("journal"), 0o644); err != nil {
+		t.Fatalf("failed to write journal file: %v", err)
+	}
+
+	ws := &config.Workspace{
+		VaultDir:       dir,
+		PinnedTaskFile: tasksPath,
+		NamedTaskPins:  config.PinMap{},
+	}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	handler := handler.NewFileHandler(dir)
+	templ, err := templater.NewTemplater(ws)
+	if err != nil {
+		t.Fatalf("failed to create templater: %v", err)
+	}
+	viewManager, err := views.NewViewManager(handler, cfg)
+	if err != nil {
+		t.Fatalf("failed to create view manager: %v", err)
+	}
+
+	st := &state.State{
+		Config:        cfg,
+		Workspace:     ws,
+		WorkspaceName: "default",
+		Templater:     templ,
+		Handler:       handler,
+		ViewManager:   viewManager,
+		Views:         viewManager.Views,
+		Vault:         dir,
+	}
+
+	noteModel, err := NewNoteListModel(st, "default")
+	if err != nil {
+		t.Fatalf("failed to create note model: %v", err)
+	}
+	tasksModel, err := taskstui.NewModel(st)
+	if err != nil {
+		t.Fatalf("failed to create tasks model: %v", err)
+	}
+	journalModel, err := journaltui.NewModel(st)
+	if err != nil {
+		t.Fatalf("failed to create journal model: %v", err)
+	}
+
+	root := NewRootModel(noteModel, tasksModel, journalModel)
+	root.Init()
+	root.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	if !strings.Contains(root.View(), "[1. Notes]") {
+		t.Fatalf("expected notes view to be active")
+	}
+
+	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	if root.active != viewTasks {
+		t.Fatalf("expected tasks view after ctrl+2, got %v", root.active)
+	}
+	if !strings.Contains(root.View(), "Pinned:") {
+		t.Fatalf("expected tasks view to render pinned status")
+	}
+
+	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	if root.active != viewJournal {
+		t.Fatalf("expected journal view after ctrl+3, got %v", root.active)
+	}
+	if !strings.Contains(root.View(), "Journal") {
+		t.Fatalf("expected journal view content in output")
+	}
+}

--- a/internal/tui/tasks/model.go
+++ b/internal/tui/tasks/model.go
@@ -1,0 +1,197 @@
+package tasks
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+
+	services "github.com/Paintersrp/an/internal/services/tasks"
+	"github.com/Paintersrp/an/internal/state"
+)
+
+type Model struct {
+	service *services.Service
+	state   *state.State
+	list    list.Model
+	keys    keyMap
+	status  string
+	width   int
+	height  int
+}
+
+type keyMap struct {
+	open    key.Binding
+	toggle  key.Binding
+	refresh key.Binding
+}
+
+type listItem struct {
+	item services.Item
+}
+
+func NewModel(s *state.State) (*Model, error) {
+	if s == nil || s.Handler == nil {
+		return nil, fmt.Errorf("task model requires a configured state handler")
+	}
+
+	svc := services.NewService(s.Handler)
+	items, err := svc.List()
+	if err != nil {
+		return nil, err
+	}
+
+	delegate := list.NewDefaultDelegate()
+	lm := list.New(toListItems(items), delegate, 0, 0)
+	lm.Title = "Tasks"
+	lm.DisableQuitKeybindings()
+
+	return &Model{
+		service: svc,
+		state:   s,
+		list:    lm,
+		keys:    newKeyMap(),
+	}, nil
+}
+
+func newKeyMap() keyMap {
+	return keyMap{
+		open: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("↵", "open note"),
+		),
+		toggle: key.NewBinding(
+			key.WithKeys("space"),
+			key.WithHelp("space", "toggle"),
+		),
+		refresh: key.NewBinding(
+			key.WithKeys("ctrl+r"),
+			key.WithHelp("ctrl+r", "refresh"),
+		),
+	}
+}
+
+func toListItems(items []services.Item) []list.Item {
+	ls := make([]list.Item, 0, len(items))
+	for _, item := range items {
+		ls = append(ls, listItem{item: item})
+	}
+	return ls
+}
+
+func (i listItem) Title() string {
+	prefix := "[ ]"
+	if i.item.Completed {
+		prefix = "[x]"
+	}
+	return fmt.Sprintf("%s %s", prefix, i.item.Content)
+}
+
+func (i listItem) Description() string {
+	rel := i.item.RelPath
+	if rel == "" {
+		rel = filepath.Base(i.item.Path)
+	}
+	return fmt.Sprintf("%s:%d", rel, i.item.Line)
+}
+
+func (i listItem) FilterValue() string {
+	return i.item.Content
+}
+
+func (m *Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.list.SetSize(msg.Width, msg.Height-2)
+		return m, nil
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.keys.toggle):
+			return m.handleToggle()
+		case key.Matches(msg, m.keys.open):
+			return m.handleOpen()
+		case key.Matches(msg, m.keys.refresh):
+			return m, m.refresh()
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m *Model) View() string {
+	pinned := ""
+	if m.state != nil && m.state.Config != nil {
+		ws := m.state.Config.MustWorkspace()
+		if ws != nil && ws.PinnedTaskFile != "" {
+			pinned = ws.PinnedTaskFile
+		}
+	}
+
+	status := m.status
+	if pinned != "" {
+		status = fmt.Sprintf("Pinned: %s", pinned)
+		if m.status != "" {
+			status = status + "\n" + m.status
+		}
+	}
+
+	if status != "" {
+		return fmt.Sprintf("%s\n%s", m.list.View(), status)
+	}
+	return m.list.View()
+}
+
+func (m *Model) handleOpen() (tea.Model, tea.Cmd) {
+	item, ok := m.list.SelectedItem().(listItem)
+	if !ok {
+		return m, nil
+	}
+
+	if err := m.service.Open(item.item.Path); err != nil {
+		m.status = fmt.Sprintf("open failed: %v", err)
+	} else {
+		m.status = fmt.Sprintf("opened %s", item.Description())
+	}
+	return m, nil
+}
+
+func (m *Model) handleToggle() (tea.Model, tea.Cmd) {
+	item, ok := m.list.SelectedItem().(listItem)
+	if !ok {
+		return m, nil
+	}
+
+	completed, err := m.service.Toggle(item.item.Path, item.item.Line)
+	if err != nil {
+		m.status = fmt.Sprintf("toggle failed: %v", err)
+		return m, nil
+	}
+
+	if completed {
+		m.status = "marked complete"
+	} else {
+		m.status = "marked incomplete"
+	}
+
+	return m, m.refresh()
+}
+
+func (m *Model) refresh() tea.Cmd {
+	items, err := m.service.List()
+	if err != nil {
+		m.status = fmt.Sprintf("refresh failed: %v", err)
+		return nil
+	}
+
+	return m.list.SetItems(toListItems(items))
+}

--- a/internal/tui/tasks/model_test.go
+++ b/internal/tui/tasks/model_test.go
@@ -1,0 +1,50 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/handler"
+	"github.com/Paintersrp/an/internal/state"
+)
+
+func TestToggleUpdatesTaskFile(t *testing.T) {
+	dir := t.TempDir()
+	atoms := filepath.Join(dir, "atoms")
+	if err := os.MkdirAll(atoms, 0o755); err != nil {
+		t.Fatalf("failed to create atoms directory: %v", err)
+	}
+	taskPath := filepath.Join(atoms, "tasks.md")
+	if err := os.WriteFile(taskPath, []byte("- [ ] example"), 0o644); err != nil {
+		t.Fatalf("failed to write tasks file: %v", err)
+	}
+
+	ws := &config.Workspace{VaultDir: dir, PinnedTaskFile: taskPath, NamedTaskPins: config.PinMap{}}
+	cfg := &config.Config{Workspaces: map[string]*config.Workspace{"default": ws}, CurrentWorkspace: "default"}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	st := &state.State{Handler: handler.NewFileHandler(dir), Config: cfg}
+	model, err := NewModel(st)
+	if err != nil {
+		t.Fatalf("failed to create tasks model: %v", err)
+	}
+
+	model.Init()
+	model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model.list.Select(0)
+	model.handleToggle()
+
+	data, err := os.ReadFile(taskPath)
+	if err != nil {
+		t.Fatalf("failed to read tasks file: %v", err)
+	}
+	if string(data) != "- [x] example" {
+		t.Fatalf("expected task to be toggled, got %q", string(data))
+	}
+}

--- a/pkg/cmd/journal/entry/entry_test.go
+++ b/pkg/cmd/journal/entry/entry_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/handler"
+	"github.com/Paintersrp/an/internal/services/journal"
 	"github.com/Paintersrp/an/internal/state"
 	"github.com/Paintersrp/an/internal/templater"
 	"github.com/Paintersrp/an/utils"
@@ -50,11 +52,14 @@ func setupEntryTest(t *testing.T) (*state.State, string) {
 		t.Fatalf("failed to create templater: %v", err)
 	}
 
+	h := handler.NewFileHandler(vaultDir)
+
 	st := &state.State{
 		Config:        cfg,
 		Workspace:     ws,
 		WorkspaceName: "default",
 		Templater:     tmpl,
+		Handler:       h,
 		Vault:         vaultDir,
 	}
 
@@ -67,7 +72,8 @@ func TestRunWithTagsOnly(t *testing.T) {
 	cmd := NewCmdEntry(st, "day")
 	args := []string{"test-tag"}
 
-	if err := run(cmd, args, st.Templater, 0, "day"); err != nil {
+	svc := journal.NewService(st.Templater, st.Handler)
+	if err := run(cmd, args, svc, 0, "day"); err != nil {
 		t.Fatalf("run returned error: %v", err)
 	}
 
@@ -90,7 +96,8 @@ func TestRunWithTagsAndInlineContent(t *testing.T) {
 	cmd := NewCmdEntry(st, "day")
 	args := []string{"inline-tag", "Inline content! #1"}
 
-	if err := run(cmd, args, st.Templater, 0, "day"); err != nil {
+	svc := journal.NewService(st.Templater, st.Handler)
+	if err := run(cmd, args, svc, 0, "day"); err != nil {
 		t.Fatalf("run returned error: %v", err)
 	}
 
@@ -131,7 +138,8 @@ func TestRunWithPasteContent(t *testing.T) {
 
 	args := []string{"paste-tag"}
 
-	if err := run(cmd, args, st.Templater, 0, "day"); err != nil {
+	svc := journal.NewService(st.Templater, st.Handler)
+	if err := run(cmd, args, svc, 0, "day"); err != nil {
 		t.Fatalf("run returned error: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- add reusable services for tasks and journal to support listing, toggling, and note launch logic
- introduce Bubble Tea models for tasks and journal and wire them into a shared root TUI alongside the notes view
- update CLI commands to use the new services and add integration tests for multi-view navigation and backend parity

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d3ebcde3208325ac4356b11337b947