### PR TITLE
fix: avoid tui metadata prompt deadlock

### DIFF
--- a/internal/tui/notes/submodels/form.go
+++ b/internal/tui/notes/submodels/form.go
@@ -302,7 +302,7 @@ func (m FormModel) handleSubmit() FormModel {
 	}
 
 	// TODO: Content instead of "" ?
-	noteLauncher(n, m.state.Templater, tmpl, "", nil)
+	noteLauncher(n, m.state.Templater, tmpl, "", map[string]interface{}{})
 
 	return m
 }


### PR DESCRIPTION
## Summary
- bypass CLI metadata prompting during note creation in the TUI by sending an empty metadata map to the launcher

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4469d962483258c5b49b3e3da204d