### PR TITLE
feat: add task metadata parsing and todo capture

### DIFF
--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -10,9 +10,9 @@ func TestParserWalkExtractsTasksAndTags(t *testing.T) {
 	dir := t.TempDir()
 	notePath := filepath.Join(dir, "note.md")
 	content := `# Title
-- [ ] first task
-- [x] completed task
-- [ ]    
+- [ ] first task @due(2024-05-20) @owner(Alice) [[Project Hub]]
+- [x] completed task @priority(high)
+- [ ]
 tags:
 - project/foo
 - project/foo
@@ -40,11 +40,23 @@ tags:
 				t.Fatalf("expected first task to be unchecked, got %q", task.Status)
 			}
 			foundUnchecked = true
+			if task.Metadata.Owner != "Alice" {
+				t.Fatalf("expected owner metadata to be Alice, got %q", task.Metadata.Owner)
+			}
+			if task.Metadata.DueDate == nil {
+				t.Fatalf("expected due date metadata to be captured")
+			}
+			if len(task.Metadata.References) != 1 || task.Metadata.References[0] != "Project Hub" {
+				t.Fatalf("expected backlink metadata to be captured, got %#v", task.Metadata.References)
+			}
 		case "completed task":
 			if task.Status != "checked" {
 				t.Fatalf("expected completed task to be checked, got %q", task.Status)
 			}
 			foundChecked = true
+			if task.Metadata.Priority != "high" {
+				t.Fatalf("expected completed task priority metadata, got %#v", task.Metadata)
+			}
 		}
 	}
 

--- a/internal/parser/task_metadata.go
+++ b/internal/parser/task_metadata.go
@@ -1,0 +1,110 @@
+package parser
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+var (
+	metadataPattern  = regexp.MustCompile(`@([a-zA-Z0-9_-]+)\(([^)]+)\)`)
+	backlinkPattern  = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
+	supportedDateFmt = []string{time.RFC3339, "2006-01-02", "2006/01/02"}
+)
+
+// ExtractTaskMetadata parses inline metadata tokens from a Markdown task body. It returns the
+// cleaned content along with a populated TaskMetadata struct. Metadata tokens follow the
+// @key(value) syntax. Supported keys include due, scheduled, priority, owner, assignee, and project.
+func ExtractTaskMetadata(content string) (string, TaskMetadata) {
+	metadata := TaskMetadata{RawTokens: make(map[string]string)}
+	trimmed := strings.TrimSpace(content)
+
+	cleaned := metadataPattern.ReplaceAllStringFunc(trimmed, func(match string) string {
+		sub := metadataPattern.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return ""
+		}
+
+		key := strings.ToLower(strings.TrimSpace(sub[1]))
+		value := strings.TrimSpace(sub[2])
+		if value == "" {
+			return ""
+		}
+
+		metadata.RawTokens[key] = value
+
+		switch key {
+		case "due":
+			if t, ok := parseDate(value); ok {
+				metadata.DueDate = &t
+			}
+		case "scheduled", "schedule", "start":
+			if t, ok := parseDate(value); ok {
+				metadata.ScheduledDate = &t
+			}
+		case "priority":
+			metadata.Priority = strings.ToLower(value)
+		case "owner", "assignee", "responsible":
+			metadata.Owner = value
+		case "project", "group":
+			metadata.Project = value
+		}
+
+		return ""
+	})
+
+	refs := backlinkPattern.FindAllStringSubmatch(trimmed, -1)
+	if len(refs) > 0 {
+		metadata.References = make([]string, 0, len(refs))
+		seen := make(map[string]struct{})
+		for _, r := range refs {
+			if len(r) < 2 {
+				continue
+			}
+			ref := strings.TrimSpace(r[1])
+			if ref == "" {
+				continue
+			}
+			if _, exists := seen[ref]; exists {
+				continue
+			}
+			seen[ref] = struct{}{}
+			metadata.References = append(metadata.References, ref)
+		}
+		sort.Strings(metadata.References)
+	}
+
+	cleaned = backlinkPattern.ReplaceAllString(cleaned, "")
+	cleaned = strings.TrimSpace(strings.Join(strings.Fields(cleaned), " "))
+
+	return cleaned, metadata
+}
+
+func parseDate(value string) (time.Time, bool) {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return time.Time{}, false
+	}
+
+	// Support relative shortcuts for today and tomorrow.
+	lower := strings.ToLower(normalized)
+	switch lower {
+	case "today":
+		now := time.Now().Local()
+		t := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		return t, true
+	case "tomorrow":
+		now := time.Now().Local().Add(24 * time.Hour)
+		t := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		return t, true
+	}
+
+	for _, layout := range supportedDateFmt {
+		if parsed, err := time.Parse(layout, normalized); err == nil {
+			return parsed, true
+		}
+	}
+
+	return time.Time{}, false
+}

--- a/internal/parser/task_metadata_test.go
+++ b/internal/parser/task_metadata_test.go
@@ -1,0 +1,47 @@
+package parser
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExtractTaskMetadataParsesTokens(t *testing.T) {
+	content := "review pull request @due(2024-12-01) @scheduled(2024-11-28) @priority(high) @project(automation) @owner(Sam) [[Release Plan]]"
+
+	cleaned, meta := ExtractTaskMetadata(content)
+	if cleaned != "review pull request" {
+		t.Fatalf("expected cleaned content, got %q", cleaned)
+	}
+	if meta.DueDate == nil || meta.DueDate.Format("2006-01-02") != "2024-12-01" {
+		t.Fatalf("expected due date to be parsed, got %#v", meta.DueDate)
+	}
+	if meta.ScheduledDate == nil || meta.ScheduledDate.Format("2006-01-02") != "2024-11-28" {
+		t.Fatalf("expected scheduled date to be parsed, got %#v", meta.ScheduledDate)
+	}
+	if meta.Priority != "high" {
+		t.Fatalf("expected priority metadata, got %q", meta.Priority)
+	}
+	if meta.Project != "automation" {
+		t.Fatalf("expected project metadata, got %q", meta.Project)
+	}
+	if meta.Owner != "Sam" {
+		t.Fatalf("expected owner metadata, got %q", meta.Owner)
+	}
+	if len(meta.References) != 1 || meta.References[0] != "Release Plan" {
+		t.Fatalf("expected backlink metadata, got %#v", meta.References)
+	}
+	if len(meta.RawTokens) != 5 {
+		t.Fatalf("expected all tokens to be recorded, got %#v", meta.RawTokens)
+	}
+}
+
+func TestParseDateRecognizesKeywords(t *testing.T) {
+	today := time.Now()
+	parsed, ok := parseDate("today")
+	if !ok {
+		t.Fatalf("expected today keyword to parse")
+	}
+	if parsed.Year() != today.Year() || parsed.Month() != today.Month() || parsed.Day() != today.Day() {
+		t.Fatalf("expected today keyword to use current day, got %v", parsed)
+	}
+}

--- a/internal/services/tasks/service_test.go
+++ b/internal/services/tasks/service_test.go
@@ -15,7 +15,7 @@ func TestServiceListIncludesPathAndStatus(t *testing.T) {
 		t.Fatalf("failed to create directory: %v", err)
 	}
 
-	content := "- [ ] first task\n- [x] done task\n"
+	content := "- [ ] first task @due(2024-01-10) @owner(Alice)\n- [x] done task @priority(low)\n"
 	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
 		t.Fatalf("failed to write file: %v", err)
 	}
@@ -36,6 +36,15 @@ func TestServiceListIncludesPathAndStatus(t *testing.T) {
 
 	if tasks[1].Completed != true {
 		t.Fatalf("expected completed task to be marked complete")
+	}
+	if tasks[0].Due == nil {
+		t.Fatalf("expected due date metadata to be carried to service item")
+	}
+	if tasks[0].Owner != "Alice" {
+		t.Fatalf("expected owner metadata to be carried to service item, got %q", tasks[0].Owner)
+	}
+	if tasks[1].Priority != "low" {
+		t.Fatalf("expected priority metadata to be carried to service item, got %q", tasks[1].Priority)
 	}
 }
 

--- a/pkg/cmd/todo/todo.go
+++ b/pkg/cmd/todo/todo.go
@@ -1,13 +1,14 @@
 package todo
 
-// full wip
-
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
@@ -15,65 +16,198 @@ import (
 	"github.com/Paintersrp/an/internal/config"
 )
 
+type options struct {
+	capture     bool
+	destination string
+}
+
+type todoEntry struct {
+	Text    string
+	Path    string
+	RelPath string
+	Line    int
+}
+
 func NewCmdTodo(c *config.Config) *cobra.Command {
+	var opts options
+
 	cmd := &cobra.Command{
 		Use:     "todo",
 		Aliases: []string{"td"},
-		Short:   "Parse TODO comments and generate a markdown checklist",
-		Long:    heredoc.Doc(``),
+		Short:   "Scan for TODO comments and surface them as actionable tasks",
+		Long: heredoc.Doc(`
+                        The todo command walks the current working directory, extracts TODO comments, and
+                        converts them into Markdown tasks. Use --capture to append the results to your vault's
+                        pinned task note (or a destination of your choice) so they appear in the Tasks TUI.
+                `),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run()
+			return run(c, opts)
 		},
 	}
+
+	cmd.Flags().BoolVar(&opts.capture, "capture", false, "append captured TODOs to the vault inbox")
+	cmd.Flags().StringVar(&opts.destination, "dest", "", "override the destination note (relative to the vault)")
 
 	return cmd
 }
 
-func run() error {
+func run(cfg *config.Config, opts options) error {
 	cwd, err := os.Getwd()
 	if err != nil {
-		fmt.Println("Error getting current working directory:", err)
+		return fmt.Errorf("failed to determine working directory: %w", err)
+	}
+
+	entries, err := collectTODOs(cwd)
+	if err != nil {
 		return err
 	}
 
+	if len(entries) == 0 {
+		fmt.Println("no TODO comments found")
+		return nil
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].RelPath == entries[j].RelPath {
+			return entries[i].Line < entries[j].Line
+		}
+		return entries[i].RelPath < entries[j].RelPath
+	})
+
+	if opts.capture {
+		if cfg == nil {
+			return errors.New("configuration is required to capture TODOs")
+		}
+		if err := appendToVault(cfg, entries, opts.destination); err != nil {
+			return err
+		}
+		fmt.Printf("captured %d TODO items into your vault\n", len(entries))
+		return nil
+	}
+
+	for _, entry := range entries {
+		fmt.Printf("- [ ] %s\n", entry.Text)
+		fmt.Printf("    - File: %s\n", entry.RelPath)
+		fmt.Printf("    - Line: %d\n", entry.Line)
+	}
+
+	return nil
+}
+
+func collectTODOs(root string) ([]todoEntry, error) {
 	todoRegex := regexp.MustCompile(
 		`(?i)(?:^|\s)(?:\/\/|#|\/\*|\*|--|<!--)\s*TODO:\s*(.+?)(?:\*\/|-->|$)`,
 	)
 
-	err = filepath.Walk(cwd, func(path string, info os.FileInfo, err error) error {
+	entries := make([]todoEntry, 0)
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			fmt.Println("Error accessing path:", path, err)
 			return err
 		}
-		if info.IsDir() && strings.HasPrefix(info.Name(), ".") {
-			return filepath.SkipDir
+		if info.IsDir() {
+			if strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
 		}
-		if !info.IsDir() {
-			content, err := os.ReadFile(path)
-			if err != nil {
-				fmt.Println("Error reading file:", path, err)
-				return err
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		lines := strings.Split(string(content), "\n")
+		for i, line := range lines {
+			if strings.Contains(line, "- [ ]") {
+				continue
 			}
 
-			lines := strings.Split(string(content), "\n")
-			for i, line := range lines {
-				if strings.Contains(line, "- [ ]") {
-					continue
-				}
-
-				matches := todoRegex.FindStringSubmatch(line)
-				if len(matches) > 1 {
-					fmt.Printf("\n- [ ] %s\n", strings.TrimSpace(matches[1]))
-					fmt.Printf("    - File: %s\n", path)
-					fmt.Printf("    - Line: %d\n", i+1)
-				}
+			matches := todoRegex.FindStringSubmatch(line)
+			if len(matches) < 2 {
+				continue
 			}
+			text := strings.TrimSpace(matches[1])
+			if text == "" {
+				continue
+			}
+
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				rel = path
+			}
+
+			entries = append(entries, todoEntry{
+				Text:    text,
+				Path:    path,
+				RelPath: filepath.ToSlash(rel),
+				Line:    i + 1,
+			})
 		}
+
 		return nil
 	})
 	if err != nil {
-		fmt.Println("Error walking through files:", err)
+		return nil, fmt.Errorf("error walking through files: %w", err)
+	}
+
+	return entries, nil
+}
+
+func appendToVault(cfg *config.Config, entries []todoEntry, override string) error {
+	ws := cfg.MustWorkspace()
+	if ws == nil {
+		return errors.New("active workspace is not configured")
+	}
+
+	dest, err := resolveDestination(ws, override)
+	if err != nil {
 		return err
 	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("failed to prepare inbox location: %w", err)
+	}
+
+	file, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open inbox note: %w", err)
+	}
+	defer file.Close()
+
+	fmt.Fprintf(file, "\n## TODO Capture %s\n\n", time.Now().Format(time.RFC3339))
+	for _, entry := range entries {
+		fmt.Fprintf(file, "- [ ] %s @project(codebase) (%s:%d)\n", entry.Text, entry.RelPath, entry.Line)
+	}
+
 	return nil
+}
+
+func resolveDestination(ws *config.Workspace, override string) (string, error) {
+	base := ws.VaultDir
+	if base == "" {
+		return "", errors.New("workspace vault directory is not configured")
+	}
+
+	chosen := strings.TrimSpace(override)
+	if chosen == "" {
+		chosen = ws.PinnedTaskFile
+	}
+	if chosen == "" {
+		chosen = filepath.Join("inbox", "code-todos.md")
+	}
+
+	if !filepath.IsAbs(chosen) {
+		chosen = filepath.Join(base, chosen)
+	}
+
+	cleaned := filepath.Clean(chosen)
+	rel, err := filepath.Rel(base, cleaned)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("destination %q is outside the vault", cleaned)
+	}
+
+	return cleaned, nil
 }

--- a/pkg/cmd/todo/todo_test.go
+++ b/pkg/cmd/todo/todo_test.go
@@ -1,0 +1,50 @@
+package todo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/config"
+)
+
+func TestCollectTODOsFindsEntries(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(file, []byte("package main\n// TODO: refactor handler\n"), 0o644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	entries, err := collectTODOs(dir)
+	if err != nil {
+		t.Fatalf("collectTODOs returned error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected one entry, got %d", len(entries))
+	}
+	if entries[0].Text != "refactor handler" {
+		t.Fatalf("expected TODO text to be trimmed, got %q", entries[0].Text)
+	}
+	if entries[0].RelPath != "main.go" {
+		t.Fatalf("expected relative path, got %q", entries[0].RelPath)
+	}
+}
+
+func TestResolveDestinationUsesPinnedTaskFile(t *testing.T) {
+	ws := &config.Workspace{VaultDir: "/tmp/vault", PinnedTaskFile: "/tmp/vault/tasks.md"}
+
+	dest, err := resolveDestination(ws, "")
+	if err != nil {
+		t.Fatalf("resolveDestination returned error: %v", err)
+	}
+	if dest != "/tmp/vault/tasks.md" {
+		t.Fatalf("expected pinned task file to be used, got %q", dest)
+	}
+}
+
+func TestResolveDestinationRejectsOutsideVault(t *testing.T) {
+	ws := &config.Workspace{VaultDir: "/tmp/vault"}
+	if _, err := resolveDestination(ws, "../other.md"); err == nil {
+		t.Fatalf("expected resolveDestination to reject paths outside the vault")
+	}
+}


### PR DESCRIPTION
## Summary
- enrich the markdown task parser with due dates, owners, projects, priorities, and backlinks, and surface the metadata in the task table service and TUI with new agenda filters
- add helpers and tests for parsing task metadata
- upgrade the todo command to optionally capture TODO comments into the vault inbox and cover it with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d445c8c35883259e462769a651a958