### PR TITLE
fix: avoid tui metadata prompt deadlock

### DIFF
--- a/internal/tui/notes/submodels/form.go
+++ b/internal/tui/notes/submodels/form.go
@@ -301,8 +301,14 @@ func (m FormModel) handleSubmit() FormModel {
 		return m
 	}
 
+	metadata, err := note.CollectTemplateMetadataNonInteractive(m.state.Templater, tmpl)
+	if err != nil {
+		fmt.Printf("error collecting template metadata: %v\n", err)
+		return m
+	}
+
 	// TODO: Content instead of "" ?
-	noteLauncher(n, m.state.Templater, tmpl, "", map[string]interface{}{})
+	noteLauncher(n, m.state.Templater, tmpl, "", metadata)
 
 	return m
 }

--- a/internal/tui/notes/submodels/form_test.go
+++ b/internal/tui/notes/submodels/form_test.go
@@ -15,6 +15,15 @@ import (
 	"github.com/Paintersrp/an/internal/templater"
 )
 
+func newTestTemplater(t *testing.T) *templater.Templater {
+	t.Helper()
+	tmpl, err := templater.NewTemplater(nil)
+	if err != nil {
+		t.Fatalf("failed to create templater: %v", err)
+	}
+	return tmpl
+}
+
 func TestHandleSubmitUsesDefaultTemplateWhenEmpty(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -31,7 +40,7 @@ func TestHandleSubmitUsesDefaultTemplateWhenEmpty(t *testing.T) {
 	model := FormModel{
 		state: &state.State{
 			Vault:     tempDir,
-			Templater: &templater.Templater{},
+			Templater: newTestTemplater(t),
 		},
 		Inputs:           inputs,
 		availableSubdirs: []string{"notes"},
@@ -89,7 +98,7 @@ func TestHandleSubmitAllowsEmptySubdirectory(t *testing.T) {
 	model := FormModel{
 		state: &state.State{
 			Vault:     tempDir,
-			Templater: &templater.Templater{},
+			Templater: newTestTemplater(t),
 		},
 		Inputs:           inputs,
 		availableSubdirs: []string{"notes"},
@@ -145,7 +154,7 @@ func TestHandleSubmitAllowsLongTitle(t *testing.T) {
 
 	model := NewFormModel(&state.State{
 		Vault:     tempDir,
-		Templater: &templater.Templater{},
+		Templater: newTestTemplater(t),
 	})
 
 	longTitle := strings.Repeat("Long title ", 3) + "with more"
@@ -227,7 +236,7 @@ func TestHandleSubmitAllowsNestedSubdirectory(t *testing.T) {
 	model := FormModel{
 		state: &state.State{
 			Vault:     tempDir,
-			Templater: &templater.Templater{},
+			Templater: newTestTemplater(t),
 		},
 		Inputs:           inputs,
 		availableSubdirs: []string{"notes"},


### PR DESCRIPTION
## Summary
- allow template metadata collection to run in noninteractive mode so default values and required field validation still apply without prompting
- have the TUI note form collect manifest metadata noninteractively before launching the note to avoid deadlocks while preserving defaults
- update note form tests to initialize a real templater fixture now that metadata collection is invoked during submission

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4484437488325989cf0be18864e9e