### PR TITLE
Fix scratchpad layout and block view switches while editing

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -570,7 +570,7 @@ func (m *NoteListModel) startInlineEdit() tea.Cmd {
 	session.setMetadata(selected.path, selected.Title(), editorModeExisting)
 	session.setValue(string(data))
 	session.setOriginal(string(data), info.ModTime())
-	session.status = "ctrl+s save • ctrl+r reload • esc discard"
+	session.status = ""
 
 	m.editor = session
 	return session.focus()
@@ -592,7 +592,7 @@ func (m *NoteListModel) startScratchCapture() tea.Cmd {
 	session.setMetadata(path, filepath.Base(path), editorModeScratch)
 	session.setValue("")
 	session.setOriginal("", time.Time{})
-	session.status = "ctrl+s save • esc discard"
+	session.status = ""
 
 	m.editor = session
 	return session.focus()
@@ -849,6 +849,13 @@ func (m NoteListModel) editorInstructions() string {
 	default:
 		return ""
 	}
+}
+
+func (m *NoteListModel) editorActive() bool {
+	if m == nil {
+		return false
+	}
+	return m.editor != nil
 }
 
 // TODO: returns are kinda unnecessary now

--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -93,14 +93,16 @@ func (m *RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case tea.KeyMsg:
+		editorActive := m.active == viewNotes && m.notes != nil && m.notes.editorActive()
+
 		switch {
-		case key.Matches(msg, m.keys.notes):
+		case !editorActive && key.Matches(msg, m.keys.notes):
 			m.active = viewNotes
 			return m, nil
-		case key.Matches(msg, m.keys.tasks):
+		case !editorActive && key.Matches(msg, m.keys.tasks):
 			m.active = viewTasks
 			return m, nil
-		case key.Matches(msg, m.keys.journal):
+		case !editorActive && key.Matches(msg, m.keys.journal):
 			m.active = viewJournal
 			return m, nil
 		case key.Matches(msg, m.keys.next):

--- a/internal/tui/notes/root_test.go
+++ b/internal/tui/notes/root_test.go
@@ -110,3 +110,27 @@ func TestRootModelNavigation(t *testing.T) {
 		t.Fatalf("expected journal view content in output")
 	}
 }
+
+func TestRootModelKeepsNotesViewWhenEditorActive(t *testing.T) {
+	noteModel := newEditorTestModel(t, map[string]string{})
+	if noteModel == nil {
+		t.Fatalf("expected note model")
+	}
+
+	root := NewRootModel(noteModel, nil, nil)
+
+	_ = noteModel.startScratchCapture()
+	if !noteModel.editorActive() {
+		t.Fatalf("expected scratch editor to be active")
+	}
+
+	_, _ = root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+
+	if root.active != viewNotes {
+		t.Fatalf("expected to remain on notes view, got %v", root.active)
+	}
+
+	if got := noteModel.editor.value(); got != "2" {
+		t.Fatalf("expected editor to capture input, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid seeding the inline editor status with default help text so the scratchpad renders correctly
- expose whether the note editor is active and skip root-level view switches while editing
- cover the editor-active behavior with a regression test

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d45b821d508325b8d7af1d81d8292a