### PR TITLE
Add resurfacing review workflows

### DIFF
--- a/internal/review/checklist.go
+++ b/internal/review/checklist.go
@@ -1,0 +1,100 @@
+package review
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+// RunChecklist steps through the provided template manifest, prompting the
+// reader for responses and displaying contextual resurfacing suggestions to the
+// writer.
+func RunChecklist(
+	manifest templater.TemplateManifest,
+	queue []ResurfaceItem,
+	reader io.Reader,
+	writer io.Writer,
+) (map[string]string, error) {
+	responses := make(map[string]string)
+	if writer == nil {
+		writer = io.Discard
+	}
+	if reader == nil {
+		reader = strings.NewReader("")
+	}
+
+	bufReader := bufio.NewReader(reader)
+	fmt.Fprintf(writer, "\n=== %s checklist ===\n", manifest.Name)
+
+	for idx, field := range manifest.Fields {
+		title := field.Label
+		if title == "" {
+			title = humanizeKey(field.Key)
+		}
+
+		fmt.Fprintf(writer, "\nStep %d: %s\n", idx+1, title)
+		if field.Prompt != "" {
+			fmt.Fprintf(writer, "%s\n", field.Prompt)
+		}
+
+		if len(field.Defaults) > 0 {
+			fmt.Fprintf(writer, "Suggested focus tags: %s\n", strings.Join(field.Defaults, ", "))
+			suggestions := FilterQueue(queue, field.Defaults, nil)
+			if len(suggestions) > 0 {
+				fmt.Fprintln(writer, "Related resurfacing candidates:")
+				for _, item := range suggestions {
+					fmt.Fprintf(
+						writer,
+						"  • %s (last touched %s)\n",
+						item.Path,
+						item.ModifiedAt.Format("2006-01-02"),
+					)
+				}
+			}
+		}
+
+		if len(field.Options) > 0 {
+			fmt.Fprintf(writer, "Options: %s\n", strings.Join(field.Options, ", "))
+		}
+
+		fmt.Fprint(writer, "> ")
+		input, err := bufReader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return responses, err
+		}
+		cleaned := strings.TrimSpace(input)
+		responses[field.Key] = cleaned
+
+		if err == io.EOF {
+			break
+		}
+	}
+
+	fmt.Fprintln(writer, "\nChecklist complete. Review notes saved for reference.")
+	return responses, nil
+}
+
+func humanizeKey(key string) string {
+	replaced := strings.ReplaceAll(key, "-", " ")
+	replaced = strings.ReplaceAll(replaced, "_", " ")
+	if replaced == "" {
+		return ""
+	}
+
+	parts := strings.Fields(replaced)
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(part)
+		if r == utf8.RuneError && size == 0 {
+			continue
+		}
+		parts[i] = strings.ToUpper(string(r)) + part[size:]
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/review/checklist_test.go
+++ b/internal/review/checklist_test.go
@@ -1,0 +1,49 @@
+package review
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+func TestRunChecklistCollectsResponsesAndSuggestions(t *testing.T) {
+	t.Parallel()
+
+	manifest := templater.TemplateManifest{
+		Name: "review-daily",
+		Fields: []templater.TemplateField{
+			{Key: "clear-inbox", Label: "Clear inbox", Prompt: "Triage the inbox", Defaults: []string{"inbox"}},
+			{Key: "plan", Prompt: "Plan"},
+		},
+	}
+
+	queue := []ResurfaceItem{
+		{
+			Path:       "notes/inbox.md",
+			Tags:       []string{"inbox"},
+			ModifiedAt: time.Now().Add(-72 * time.Hour),
+			Age:        72 * time.Hour,
+			Bucket:     "every-3-days",
+		},
+	}
+
+	input := strings.NewReader("done\nnext\n")
+	var output bytes.Buffer
+
+	responses, err := RunChecklist(manifest, queue, input, &output)
+	if err != nil {
+		t.Fatalf("RunChecklist returned error: %v", err)
+	}
+
+	if responses["clear-inbox"] != "done" || responses["plan"] != "next" {
+		t.Fatalf("unexpected responses: %#v", responses)
+	}
+
+	text := output.String()
+	if !strings.Contains(text, "Related resurfacing candidates") {
+		t.Fatalf("expected suggestions in output, got %q", text)
+	}
+}

--- a/internal/review/graph.go
+++ b/internal/review/graph.go
@@ -1,0 +1,54 @@
+package review
+
+import "github.com/Paintersrp/an/internal/search"
+
+// GraphNode represents backlinks and outbound connections for a note.
+type GraphNode struct {
+	Path      string
+	Outbound  []string
+	Backlinks []string
+}
+
+// Graph captures a backlink graph for the provided seeds.
+type Graph struct {
+	Nodes map[string]GraphNode
+}
+
+// BuildBacklinkGraph constructs a backlink graph for the provided seed paths.
+// The resulting graph includes seed nodes and their direct neighbors.
+func BuildBacklinkGraph(idx *search.Index, seeds []string) Graph {
+	graph := Graph{Nodes: make(map[string]GraphNode)}
+	if idx == nil {
+		return graph
+	}
+
+	visited := make(map[string]struct{})
+	for _, seed := range seeds {
+		if _, ok := visited[seed]; ok {
+			continue
+		}
+		visited[seed] = struct{}{}
+
+		related := idx.Related(seed)
+		node := GraphNode{
+			Path:      seed,
+			Outbound:  append([]string(nil), related.Outbound...),
+			Backlinks: append([]string(nil), related.Backlinks...),
+		}
+		graph.Nodes[seed] = node
+
+		for _, neighbor := range append(append([]string(nil), node.Outbound...), node.Backlinks...) {
+			if _, ok := graph.Nodes[neighbor]; ok {
+				continue
+			}
+			relatedNeighbor := idx.Related(neighbor)
+			graph.Nodes[neighbor] = GraphNode{
+				Path:      neighbor,
+				Outbound:  append([]string(nil), relatedNeighbor.Outbound...),
+				Backlinks: append([]string(nil), relatedNeighbor.Backlinks...),
+			}
+		}
+	}
+
+	return graph
+}

--- a/internal/review/graph_test.go
+++ b/internal/review/graph_test.go
@@ -1,0 +1,55 @@
+package review
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/an/internal/search"
+)
+
+func TestBuildBacklinkGraph(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	alpha := writeNote(t, dir, "alpha.md", fixedTime())
+	beta := writeNote(t, dir, "beta.md", fixedTime())
+	gamma := writeNote(t, dir, "gamma.md", fixedTime())
+
+	writeFile(t, alpha, "[[beta]]\n")
+	writeFile(t, beta, "[[gamma]]\n[[alpha]]\n")
+	writeFile(t, gamma, "No links\n")
+
+	idx := search.NewIndex(dir, search.Config{})
+	if err := idx.Build([]string{alpha, beta, gamma}); err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	graph := BuildBacklinkGraph(idx, []string{alpha})
+	if len(graph.Nodes) == 0 {
+		t.Fatalf("expected graph nodes, got 0")
+	}
+
+	node, ok := graph.Nodes[filepath.Clean(alpha)]
+	if !ok {
+		t.Fatalf("missing alpha node: %#v", graph.Nodes)
+	}
+	if len(node.Outbound) != 1 || node.Outbound[0] != filepath.Clean(beta) {
+		t.Fatalf("unexpected outbound: %#v", node.Outbound)
+	}
+	if len(node.Backlinks) != 1 || node.Backlinks[0] != filepath.Clean(beta) {
+		t.Fatalf("unexpected backlinks: %#v", node.Backlinks)
+	}
+}
+
+func fixedTime() time.Time {
+	return time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}

--- a/internal/review/resurface.go
+++ b/internal/review/resurface.go
@@ -1,0 +1,206 @@
+package review
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Paintersrp/an/internal/search"
+)
+
+// Bucket represents a resurfacing cadence bucket.
+type Bucket struct {
+	// Name is the human readable label for the bucket (for example "weekly").
+	Name string
+	// After specifies the minimum age a note must reach before falling into the
+	// bucket. Buckets are evaluated from the smallest After duration to the
+	// largest, with the last matching bucket winning.
+	After time.Duration
+}
+
+// ResurfaceOptions configures queue generation.
+type ResurfaceOptions struct {
+	Now        time.Time
+	MinimumAge time.Duration
+	Limit      int
+	Buckets    []Bucket
+	Query      search.Query
+}
+
+// ResurfaceItem captures queue metadata for a resurfaced note.
+type ResurfaceItem struct {
+	Path       string
+	Tags       []string
+	Metadata   map[string][]string
+	Links      []string
+	ModifiedAt time.Time
+	Age        time.Duration
+	Bucket     string
+}
+
+// DefaultBuckets returns the default resurfacing cadence buckets.
+func DefaultBuckets() []Bucket {
+	return []Bucket{
+		{Name: "daily", After: 24 * time.Hour},
+		{Name: "every-3-days", After: 72 * time.Hour},
+		{Name: "weekly", After: 7 * 24 * time.Hour},
+		{Name: "biweekly", After: 14 * 24 * time.Hour},
+		{Name: "monthly", After: 30 * 24 * time.Hour},
+	}
+}
+
+// BuildResurfaceQueue evaluates the index metadata and returns the resurfacing
+// queue ordered from stalest to freshest.
+func BuildResurfaceQueue(idx *search.Index, opts ResurfaceOptions) []ResurfaceItem {
+	if idx == nil {
+		return nil
+	}
+
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	buckets := append([]Bucket(nil), opts.Buckets...)
+	if len(buckets) == 0 {
+		buckets = DefaultBuckets()
+	}
+	sort.Slice(buckets, func(i, j int) bool {
+		return buckets[i].After < buckets[j].After
+	})
+
+	docs := idx.FilteredDocuments(opts.Query)
+	if len(docs) == 0 {
+		return nil
+	}
+
+	items := make([]ResurfaceItem, 0, len(docs))
+	for _, doc := range docs {
+		age := now.Sub(doc.ModifiedAt)
+		if opts.MinimumAge > 0 && age < opts.MinimumAge {
+			continue
+		}
+
+		bucket := determineBucket(age, buckets)
+		if bucket == "" {
+			continue
+		}
+
+		items = append(items, ResurfaceItem{
+			Path:       doc.Path,
+			Tags:       append([]string(nil), doc.Tags...),
+			Metadata:   cloneMetadata(doc.FrontMatter),
+			Links:      append([]string(nil), doc.Links...),
+			ModifiedAt: doc.ModifiedAt,
+			Age:        age,
+			Bucket:     bucket,
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Bucket != items[j].Bucket {
+			return bucketRank(items[i].Bucket, buckets) > bucketRank(items[j].Bucket, buckets)
+		}
+		if !items[i].ModifiedAt.Equal(items[j].ModifiedAt) {
+			return items[i].ModifiedAt.Before(items[j].ModifiedAt)
+		}
+		return items[i].Path < items[j].Path
+	})
+
+	if opts.Limit > 0 && len(items) > opts.Limit {
+		items = items[:opts.Limit]
+	}
+	return items
+}
+
+func determineBucket(age time.Duration, buckets []Bucket) string {
+	matched := ""
+	for _, bucket := range buckets {
+		if age >= bucket.After {
+			matched = bucket.Name
+		}
+	}
+	return matched
+}
+
+func bucketRank(name string, buckets []Bucket) int {
+	for idx, bucket := range buckets {
+		if bucket.Name == name {
+			return idx
+		}
+	}
+	return len(buckets)
+}
+
+func cloneMetadata(values map[string][]string) map[string][]string {
+	if len(values) == 0 {
+		return nil
+	}
+	copied := make(map[string][]string, len(values))
+	for key, vals := range values {
+		copied[key] = append([]string(nil), vals...)
+	}
+	return copied
+}
+
+// FilterQueue filters resurfacing items by tags and metadata, returning the
+// subset that satisfies all requested filters.
+func FilterQueue(items []ResurfaceItem, tags []string, metadata map[string][]string) []ResurfaceItem {
+	if len(tags) == 0 && len(metadata) == 0 {
+		return items
+	}
+
+	filtered := make([]ResurfaceItem, 0, len(items))
+	for _, item := range items {
+		if len(tags) > 0 && !containsAllTags(item.Tags, tags) {
+			continue
+		}
+		if len(metadata) > 0 && !matchesMetadata(item.Metadata, metadata) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func containsAllTags(tags, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+
+	lookup := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		lookup[strings.ToLower(tag)] = struct{}{}
+	}
+
+	for _, want := range required {
+		if _, ok := lookup[strings.ToLower(want)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesMetadata(values map[string][]string, required map[string][]string) bool {
+	for key, wantValues := range required {
+		available, ok := values[key]
+		if !ok {
+			return false
+		}
+
+		wantLookup := make(map[string]struct{}, len(wantValues))
+		for _, want := range wantValues {
+			wantLookup[strings.ToLower(want)] = struct{}{}
+		}
+
+		for _, have := range available {
+			lowered := strings.ToLower(have)
+			delete(wantLookup, lowered)
+		}
+
+		if len(wantLookup) > 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/review/resurface_test.go
+++ b/internal/review/resurface_test.go
@@ -1,0 +1,86 @@
+package review
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/an/internal/search"
+)
+
+func TestBuildResurfaceQueueAppliesBuckets(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2024, 1, 10, 12, 0, 0, 0, time.UTC)
+
+	stale := writeNote(t, dir, "stale.md", now.Add(-10*24*time.Hour))
+	mid := writeNote(t, dir, "mid.md", now.Add(-4*24*time.Hour))
+	fresh := writeNote(t, dir, "fresh.md", now.Add(-6*time.Hour))
+
+	idx := search.NewIndex(dir, search.Config{})
+	if err := idx.Build([]string{stale, mid, fresh}); err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	queue := BuildResurfaceQueue(idx, ResurfaceOptions{
+		Now: now,
+		Buckets: []Bucket{
+			{Name: "daily", After: 24 * time.Hour},
+			{Name: "weekly", After: 7 * 24 * time.Hour},
+		},
+	})
+
+	if len(queue) != 2 {
+		t.Fatalf("expected 2 resurfaced notes, got %d", len(queue))
+	}
+
+	if queue[0].Path != filepath.Clean(stale) || queue[0].Bucket != "weekly" {
+		t.Fatalf("unexpected first queue item: %+v", queue[0])
+	}
+	if queue[1].Path != filepath.Clean(mid) || queue[1].Bucket != "daily" {
+		t.Fatalf("unexpected second queue item: %+v", queue[1])
+	}
+}
+
+func TestFilterQueueFiltersByTagsAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	queue := []ResurfaceItem{
+		{
+			Path:       "a.md",
+			Tags:       []string{"weekly", "project"},
+			Metadata:   map[string][]string{"status": []string{"active"}},
+			ModifiedAt: now.Add(-48 * time.Hour),
+			Age:        48 * time.Hour,
+			Bucket:     "daily",
+		},
+		{
+			Path:       "b.md",
+			Tags:       []string{"daily"},
+			Metadata:   map[string][]string{"status": []string{"paused"}},
+			ModifiedAt: now.Add(-120 * time.Hour),
+			Age:        120 * time.Hour,
+			Bucket:     "weekly",
+		},
+	}
+
+	filtered := FilterQueue(queue, []string{"project"}, map[string][]string{"status": []string{"active"}})
+	if len(filtered) != 1 || filtered[0].Path != "a.md" {
+		t.Fatalf("unexpected filtered queue: %+v", filtered)
+	}
+}
+
+func writeNote(t *testing.T, dir, name string, modTime time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("---\ntitle: Note\n---\nbody"), 0o644); err != nil {
+		t.Fatalf("write note: %v", err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return path
+}

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -39,6 +39,9 @@ var AvailableTemplates = map[string]bool{
 	"echo":            true,
 	"sum":             true,
 	"year":            true,
+	"review-daily":    true,
+	"review-weekly":   true,
+	"review-retro":    true,
 }
 
 type SingleTemplate struct {

--- a/internal/templater/templates/review-daily.tmpl
+++ b/internal/templater/templates/review-daily.tmpl
@@ -1,0 +1,23 @@
+{{/* an:manifest
+name: review-daily
+description: Daily review checklist that clears capture queues and plans focus blocks.
+fields:
+  - key: clear-inbox
+    label: Clear capture inbox
+    prompt: Promote captured notes or archive what is no longer needed.
+    defaults: [inbox]
+  - key: focus-plan
+    label: Plan focus blocks
+    prompt: Reserve time for the highest-leverage work today.
+    defaults: [today, priority]
+  - key: sweep-tasks
+    label: Sweep lingering todos
+    prompt: Close or reprioritize lingering tasks surfaced during review.
+*/}}
+# Daily Review Ritual
+
+- [ ] Clear capture inbox
+- [ ] Plan focus blocks
+- [ ] Sweep lingering todos
+
+Take notes on the prompts as you work through the checklist to capture insights or follow-ups.

--- a/internal/templater/templates/review-retro.tmpl
+++ b/internal/templater/templates/review-retro.tmpl
@@ -1,0 +1,23 @@
+{{/* an:manifest
+name: review-retro
+description: Project retrospective checklist that captures successes, lessons, and next experiments.
+fields:
+  - key: successes
+    label: Capture successes
+    prompt: Record the outcomes, wins, or positive surprises from this project.
+    defaults: [project]
+  - key: lessons
+    label: Harvest lessons
+    prompt: Document what should change next time and what worked well.
+  - key: experiments
+    label: Define next experiments
+    prompt: Queue experiments or follow-up tasks to apply the lessons.
+    defaults: [next, retro]
+*/}}
+# Project Retrospective Ritual
+
+- [ ] Capture successes
+- [ ] Harvest lessons
+- [ ] Define next experiments
+
+Link to supporting notes or action items directly in this checklist to keep retrospectives actionable.

--- a/internal/templater/templates/review-weekly.tmpl
+++ b/internal/templater/templates/review-weekly.tmpl
@@ -1,0 +1,23 @@
+{{/* an:manifest
+name: review-weekly
+description: Weekly review checklist for consolidating wins, removing blockers, and planning the next sprint.
+fields:
+  - key: celebrate-wins
+    label: Celebrate wins
+    prompt: Summarize the biggest highlights and outcomes from this week.
+  - key: clear-blockers
+    label: Clear blockers
+    prompt: Unstick notes or tasks that linger in the weekly resurfacing queue.
+    defaults: [weekly, blocked]
+  - key: plan-next
+    label: Plan the next sprint
+    prompt: Choose the projects that deserve focus next week.
+    defaults: [project]
+*/}}
+# Weekly Review Ritual
+
+- [ ] Celebrate wins
+- [ ] Clear blockers
+- [ ] Plan the next sprint
+
+Log any retrospective notes or follow-up actions alongside this checklist to keep the next iteration grounded.

--- a/pkg/cmd/review/review.go
+++ b/pkg/cmd/review/review.go
@@ -1,0 +1,299 @@
+package review
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	reviewsvc "github.com/Paintersrp/an/internal/review"
+	"github.com/Paintersrp/an/internal/search"
+	"github.com/Paintersrp/an/internal/state"
+)
+
+// metadataFlag captures repeated key=value metadata filters.
+type metadataFlag map[string][]string
+
+func (m metadataFlag) String() string {
+	if len(m) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(m))
+	for key, values := range m {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, strings.Join(values, ",")))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ";")
+}
+
+func (m metadataFlag) Type() string {
+	return "key=value"
+}
+
+func (m metadataFlag) Set(value string) error {
+	if value == "" {
+		return nil
+	}
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("metadata must be key=value, got %q", value)
+	}
+	key := strings.TrimSpace(parts[0])
+	if key == "" {
+		return errors.New("metadata key cannot be empty")
+	}
+	values := strings.Split(parts[1], ",")
+	cleaned := make([]string, 0, len(values))
+	for _, v := range values {
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			continue
+		}
+		cleaned = append(cleaned, trimmed)
+	}
+	if len(cleaned) == 0 {
+		return fmt.Errorf("metadata %q has no values", key)
+	}
+	m[key] = append(m[key], cleaned...)
+	return nil
+}
+
+// NewCmdReview wires the `review` command that orchestrates resurfacing,
+// backlink visualization, and guided checklists.
+func NewCmdReview(s *state.State) *cobra.Command {
+	var (
+		mode      string
+		limit     int
+		minAge    time.Duration
+		showGraph bool
+		tags      []string
+		meta      = make(metadataFlag)
+	)
+
+	cmd := &cobra.Command{
+		Use:   "review",
+		Short: "Run guided review rituals backed by resurfacing queues",
+		Long: `Review assembles the notes that deserve another look,
+surfaces how they connect, and walks you through a repeatable checklist.
+Use it to keep daily, weekly, or project retrospectives inside your vault.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if s == nil {
+				return errors.New("state is not configured")
+			}
+
+			ws := s.Config.MustWorkspace()
+			searchCfg := search.Config{
+				EnableBody:     ws.Search.EnableBody,
+				IgnoredFolders: append([]string(nil), ws.Search.IgnoredFolders...),
+			}
+
+			query := search.Query{
+				Tags:     append([]string(nil), ws.Search.DefaultTagFilters...),
+				Metadata: cloneMetadata(ws.Search.DefaultMetadataFilters),
+			}
+			query.Tags = append(query.Tags, tags...)
+			for key, values := range meta {
+				query.Metadata[key] = append(query.Metadata[key], values...)
+			}
+
+			paths, err := collectNotePaths(s.Vault, searchCfg.IgnoredFolders)
+			if err != nil {
+				return err
+			}
+
+			idx := search.NewIndex(s.Vault, searchCfg)
+			if err := idx.Build(paths); err != nil {
+				return fmt.Errorf("build search index: %w", err)
+			}
+
+			queue := reviewsvc.BuildResurfaceQueue(idx, reviewsvc.ResurfaceOptions{
+				Now:        time.Now(),
+				MinimumAge: minAge,
+				Limit:      limit,
+				Buckets:    reviewsvc.DefaultBuckets(),
+				Query:      query,
+			})
+
+			out := cmd.OutOrStdout()
+			if len(queue) == 0 {
+				fmt.Fprintln(out, "No notes are due for resurfacing.")
+			} else {
+				fmt.Fprintf(out, "Resurfacing queue (%d items):\n", len(queue))
+				for i, item := range queue {
+					fmt.Fprintf(
+						out,
+						"%2d. %s — last touched %s (%s)\n",
+						i+1,
+						relPath(s.Vault, item.Path),
+						humanizeAge(item.Age),
+						item.Bucket,
+					)
+				}
+			}
+
+			if showGraph && len(queue) > 0 {
+				fmt.Fprintln(out, "\nBacklink graph:")
+				seedPaths := make([]string, 0, len(queue))
+				for _, item := range queue {
+					seedPaths = append(seedPaths, item.Path)
+				}
+				graph := reviewsvc.BuildBacklinkGraph(idx, seedPaths)
+				printGraph(out, graph, s.Vault)
+			}
+
+			templateName, err := resolveTemplate(mode)
+			if err != nil {
+				return err
+			}
+
+			manifest, err := s.Templater.Manifest(templateName)
+			if err != nil {
+				return fmt.Errorf("load %s manifest: %w", templateName, err)
+			}
+
+			_, err = reviewsvc.RunChecklist(
+				manifest,
+				queue,
+				cmd.InOrStdin(),
+				out,
+			)
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&mode, "mode", "daily", "Review mode to run (daily, weekly, retro)")
+	cmd.Flags().IntVar(&limit, "limit", 12, "Maximum resurfacing candidates to include")
+	cmd.Flags().DurationVar(&minAge, "min-age", 0, "Minimum age (for example 48h) before resurfacing a note")
+	cmd.Flags().BoolVar(&showGraph, "graph", false, "Render a backlink graph for resurfacing candidates")
+	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Additional tag filters to apply to the resurfacing queue")
+	cmd.Flags().Var(meta, "metadata", "Metadata filter in key=value form (repeatable)")
+
+	return cmd
+}
+
+func collectNotePaths(root string, ignored []string) ([]string, error) {
+	normalized := make(map[string]struct{}, len(ignored))
+	for _, dir := range ignored {
+		normalized[strings.ToLower(dir)] = struct{}{}
+	}
+
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			name := strings.ToLower(d.Name())
+			if strings.HasPrefix(name, ".") && path != root {
+				return filepath.SkipDir
+			}
+			if _, skip := normalized[name]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) == ".md" {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func cloneMetadata(values map[string][]string) map[string][]string {
+	if len(values) == 0 {
+		return make(map[string][]string)
+	}
+	cloned := make(map[string][]string, len(values))
+	for key, vals := range values {
+		cloned[key] = append([]string(nil), vals...)
+	}
+	return cloned
+}
+
+func resolveTemplate(mode string) (string, error) {
+	switch strings.ToLower(mode) {
+	case "daily":
+		return "review-daily", nil
+	case "weekly":
+		return "review-weekly", nil
+	case "retro", "project", "project-retro":
+		return "review-retro", nil
+	default:
+		return "", fmt.Errorf("unknown review mode %q", mode)
+	}
+}
+
+func humanizeAge(age time.Duration) string {
+	if age < time.Hour {
+		minutes := int(age.Minutes())
+		if minutes <= 1 {
+			return "1 minute"
+		}
+		return fmt.Sprintf("%d minutes", minutes)
+	}
+	days := int(age.Hours() / 24)
+	if days == 0 {
+		hours := int(age.Hours())
+		if hours == 1 {
+			return "1 hour"
+		}
+		return fmt.Sprintf("%d hours", hours)
+	}
+	if days == 1 {
+		return "1 day"
+	}
+	return fmt.Sprintf("%d days", days)
+}
+
+func printGraph(out io.Writer, graph reviewsvc.Graph, root string) {
+	if out == nil {
+		return
+	}
+
+	paths := make([]string, 0, len(graph.Nodes))
+	for path := range graph.Nodes {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		node := graph.Nodes[path]
+		fmt.Fprintf(out, "- %s\n", relPath(root, node.Path))
+		if len(node.Backlinks) > 0 {
+			fmt.Fprintf(out, "    ← %s\n", joinPaths(root, node.Backlinks))
+		}
+		if len(node.Outbound) > 0 {
+			fmt.Fprintf(out, "    → %s\n", joinPaths(root, node.Outbound))
+		}
+	}
+}
+
+func relPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return path
+	}
+	return rel
+}
+
+func joinPaths(root string, paths []string) string {
+	converted := make([]string, 0, len(paths))
+	for _, p := range paths {
+		converted = append(converted, relPath(root, p))
+	}
+	return strings.Join(converted, ", ")
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -15,7 +15,8 @@ import (
 	"github.com/Paintersrp/an/pkg/cmd/notes"
 	"github.com/Paintersrp/an/pkg/cmd/open"
 	"github.com/Paintersrp/an/pkg/cmd/pin"
-	"github.com/Paintersrp/an/pkg/cmd/settings"
+        "github.com/Paintersrp/an/pkg/cmd/review"
+        "github.com/Paintersrp/an/pkg/cmd/settings"
 	"github.com/Paintersrp/an/pkg/cmd/symlink"
 	"github.com/Paintersrp/an/pkg/cmd/tags"
 	"github.com/Paintersrp/an/pkg/cmd/tasks"
@@ -74,8 +75,9 @@ func NewCmdRoot(s *state.State) (*cobra.Command, error) {
 		tasks.NewCmdTasks(s),
 		pin.NewCmdPin(s, "text"),
 		echo.NewCmdEcho(s),
-		capture.NewCmdCapture(s),
-		settings.NewCmdSettings(s),
+                capture.NewCmdCapture(s),
+                review.NewCmdReview(s),
+                settings.NewCmdSettings(s),
 		symlink.NewCmdSymlink(s),
 		notes.NewCmdNotes(s),
 		todo.NewCmdTodo(s.Config),


### PR DESCRIPTION
## Summary
- add a resurfacing service that tracks note ages with the search index and exposes queue/filter helpers
- build backlink graph and guided checklist utilities to power review rituals
- introduce a `review` command with daily, weekly, and project retrospective templates and register them with the CLI

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d459a3379c8325ae359542c681a72b