### PR TITLE
Enhance search ranking with relevance scoring and fuzzy matching

### DIFF
--- a/internal/search/config.go
+++ b/internal/search/config.go
@@ -27,4 +27,6 @@ type Result struct {
 	Path      string
 	Snippet   string
 	MatchFrom string
+	Score     float64
+	Related   RelatedNotes
 }


### PR DESCRIPTION
## Summary
- add scoring metadata to search results and rank matches using recency, term frequency, and filter overlap
- enable fuzzy matching across filenames, headings, and titles while surfacing related note relationships in results
- cover the new behavior with focused unit tests and add benchmarks comparing ranked and alphabetical search performance

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d462a0bf788325a44d924e85077fe3