### PR TITLE
Fix note list selection after filtering

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -543,6 +543,8 @@ func (m NoteListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.list = nl
 	cmds = append(cmds, cmd)
 
+	m.ensureSelectionInBounds()
+
 	if nextSelection := m.currentSelectionPath(); nextSelection != previousSelection {
 		if nextSelection == "" {
 			m.preview = ""
@@ -562,6 +564,18 @@ func (m NoteListModel) currentSelectionPath() string {
 	}
 
 	return ""
+}
+
+func (m *NoteListModel) ensureSelectionInBounds() {
+	visible := m.list.VisibleItems()
+	if len(visible) == 0 {
+		m.list.ResetSelected()
+		return
+	}
+
+	if idx := m.list.Index(); idx >= len(visible) {
+		m.list.ResetSelected()
+	}
 }
 
 func (m NoteListModel) handleCopyUpdate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -51,6 +51,40 @@ func TestCycleViewOrder(t *testing.T) {
 	}
 }
 
+func TestEnsureSelectionInBoundsResetsOutOfRangeCursor(t *testing.T) {
+	t.Parallel()
+
+	delegate := list.NewDefaultDelegate()
+	items := []list.Item{
+		ListItem{fileName: "one.md", path: "one"},
+		ListItem{fileName: "two.md", path: "two"},
+		ListItem{fileName: "three.md", path: "three"},
+	}
+
+	l := list.New(items, delegate, 0, 0)
+	l.SetSize(80, 30)
+	l.Select(2)
+
+	model := &NoteListModel{list: l}
+
+	reduced := []list.Item{items[0]}
+	model.list.SetItems(reduced)
+
+	if idx := model.list.Index(); idx == 0 {
+		t.Fatalf("expected index to remain out of bounds before enforcing selection, got %d", idx)
+	}
+
+	model.ensureSelectionInBounds()
+
+	if idx := model.list.Index(); idx != 0 {
+		t.Fatalf("expected index to reset to 0, got %d", idx)
+	}
+
+	if _, ok := model.list.SelectedItem().(ListItem); !ok {
+		t.Fatalf("expected a selected item after resetting selection")
+	}
+}
+
 func TestToggleRenameSeedsInputValue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- ensure the note list resets its selection when filters shrink the visible set so navigation stays on valid items
- add a regression test that covers the out-of-range cursor scenario after items are reduced

## Testing
- go test ./... *(fails: note editor template tests expect different command args in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4660f750c8325ae0c27dc5257768f