### PR TITLE
Clamp note list selection after refreshing items

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -543,6 +543,8 @@ func (m NoteListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.list = nl
 	cmds = append(cmds, cmd)
 
+	m.ensureSelectionInBounds()
+
 	if nextSelection := m.currentSelectionPath(); nextSelection != previousSelection {
 		if nextSelection == "" {
 			m.preview = ""
@@ -562,6 +564,18 @@ func (m NoteListModel) currentSelectionPath() string {
 	}
 
 	return ""
+}
+
+func (m *NoteListModel) ensureSelectionInBounds() {
+	visible := m.list.VisibleItems()
+	if len(visible) == 0 {
+		m.list.ResetSelected()
+		return
+	}
+
+	if idx := m.list.Index(); idx >= len(visible) {
+		m.list.ResetSelected()
+	}
 }
 
 func (m NoteListModel) handleCopyUpdate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -1282,7 +1296,9 @@ func (m *NoteListModel) refreshItems() tea.Cmd {
 	sortedItems := sortItems(castToListItems(items), m.sortField, m.sortOrder)
 	attachHighlightStore(sortedItems, m.highlights)
 	m.rebuildSearch(files)
-	return m.list.SetItems(sortedItems)
+	cmd := m.list.SetItems(sortedItems)
+	m.ensureSelectionInBounds()
+	return cmd
 }
 
 func (m *NoteListModel) refreshDelegate() {

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -1,6 +1,8 @@
 package notes
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -48,6 +50,104 @@ func TestCycleViewOrder(t *testing.T) {
 		if got := model.viewName; got != want {
 			t.Fatalf("step %d: expected view %q, got %q", i+1, want, got)
 		}
+	}
+}
+
+func TestRefreshItemsClampsSelectionWhenListShrinks(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	fileNames := []string{"one.md", "two.md", "three.md"}
+	for _, name := range fileNames {
+		path := filepath.Join(tempDir, name)
+		if err := os.WriteFile(path, []byte("content"), 0o644); err != nil {
+			t.Fatalf("failed to write file %s: %v", name, err)
+		}
+	}
+
+	fileHandler := handler.NewFileHandler(tempDir)
+	ws := &config.Workspace{VaultDir: tempDir}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	viewManager, err := views.NewViewManager(fileHandler, cfg)
+	if err != nil {
+		t.Fatalf("NewViewManager returned error: %v", err)
+	}
+
+	model, err := NewNoteListModel(&state.State{
+		Config:        cfg,
+		Workspace:     ws,
+		WorkspaceName: cfg.CurrentWorkspace,
+		Handler:       fileHandler,
+		ViewManager:   viewManager,
+		Vault:         tempDir,
+	}, "default")
+	if err != nil {
+		t.Fatalf("NewNoteListModel returned error: %v", err)
+	}
+
+	if items := len(model.list.Items()); items != len(fileNames) {
+		t.Fatalf("expected %d items, got %d", len(fileNames), items)
+	}
+
+	model.list.Select(2)
+
+	removed := filepath.Join(tempDir, "three.md")
+	if err := os.Remove(removed); err != nil {
+		t.Fatalf("failed to remove %s: %v", removed, err)
+	}
+
+	if cmd := model.refreshItems(); cmd != nil {
+		t.Fatalf("expected refreshItems command to be nil, got %T", cmd)
+	}
+
+	visible := model.list.VisibleItems()
+	if idx := model.list.Index(); idx < 0 || idx >= len(visible) {
+		t.Fatalf("expected selection to be within bounds, got index %d with %d visible items", idx, len(visible))
+	}
+
+	if _, ok := model.list.SelectedItem().(ListItem); !ok {
+		t.Fatalf("expected a selected item after refreshing list")
+	}
+}
+
+func TestEnsureSelectionInBoundsResetsOutOfRangeCursor(t *testing.T) {
+	t.Parallel()
+
+	delegate := list.NewDefaultDelegate()
+	items := []list.Item{
+		ListItem{fileName: "one.md", path: "one"},
+		ListItem{fileName: "two.md", path: "two"},
+		ListItem{fileName: "three.md", path: "three"},
+	}
+
+	l := list.New(items, delegate, 0, 0)
+	l.SetSize(80, 30)
+	l.Select(2)
+
+	model := &NoteListModel{list: l}
+
+	reduced := []list.Item{items[0]}
+	model.list.SetItems(reduced)
+
+	if idx := model.list.Index(); idx == 0 {
+		t.Fatalf("expected index to remain out of bounds before enforcing selection, got %d", idx)
+	}
+
+	model.ensureSelectionInBounds()
+
+	if idx := model.list.Index(); idx != 0 {
+		t.Fatalf("expected index to reset to 0, got %d", idx)
+	}
+
+	if _, ok := model.list.SelectedItem().(ListItem); !ok {
+		t.Fatalf("expected a selected item after resetting selection")
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure refreshItems keeps the list selection inside the visible range after reloading items
- add a regression test covering list refreshes that shrink the dataset

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4660f750c8325ae0c27dc5257768f