### PR TITLE
Clamp note list selection after refreshing items

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -591,13 +591,13 @@ func (m NoteListModel) currentSelectionPath() string {
 }
 
 func (m *NoteListModel) ensureSelectionInBounds() {
-	visible := m.list.VisibleItems()
-	if len(visible) == 0 {
+	items := m.list.Items()
+	if len(items) == 0 {
 		m.list.ResetSelected()
 		return
 	}
 
-	if idx := m.list.Index(); idx >= len(visible) {
+	if idx := m.list.Index(); idx >= len(items) {
 		m.list.ResetSelected()
 	}
 }

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -109,9 +109,9 @@ func TestRefreshItemsClampsSelectionWhenListShrinks(t *testing.T) {
 		t.Fatalf("expected refreshItems command to be nil, got %T", cmd)
 	}
 
-	visible := model.list.VisibleItems()
-	if idx := model.list.Index(); idx < 0 || idx >= len(visible) {
-		t.Fatalf("expected selection to be within bounds, got index %d with %d visible items", idx, len(visible))
+	items := model.list.Items()
+	if idx := model.list.Index(); idx < 0 || idx >= len(items) {
+		t.Fatalf("expected selection to be within bounds, got index %d with %d items", idx, len(items))
 	}
 
 	if _, ok := model.list.SelectedItem().(ListItem); !ok {


### PR DESCRIPTION
## Summary
- clamp the refreshed selection against the list's total item count instead of the visible viewport
- keep the regression test verifying the selection remains within the available items after shrinking the dataset

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4717c94e08325b2b242e9342c5530