### PR TITLE
Ensure list pane redraw clears filtered rows

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -46,6 +46,8 @@ type NoteListModel struct {
 	inputModel          submodels.InputModel
 	width               int
 	height              int
+	listWidth           int
+	previewWidth        int
 	renaming            bool
 	showDetails         bool
 	creating            bool
@@ -317,6 +319,10 @@ func (m *NoteListModel) makeFilterFunc() list.FilterFunc {
 		}
 
 		baseRanks := base(term, targets)
+		matchedIndexes := make(map[int][]int, len(baseRanks))
+		for _, rank := range baseRanks {
+			matchedIndexes[rank.Index] = rank.MatchedIndexes
+		}
 
 		if m.searchIndex == nil {
 			return baseRanks
@@ -355,16 +361,36 @@ func (m *NoteListModel) makeFilterFunc() list.FilterFunc {
 			}
 		}
 
-		highlightRanks := make([]list.Rank, 0, len(orderedPaths))
+		searchRanks := make([]list.Rank, 0, len(orderedPaths))
 		for _, path := range orderedPaths {
 			if idx, ok := indexByPath[path]; ok {
-				highlightRanks = append(highlightRanks, list.Rank{Index: idx})
+				rank := list.Rank{Index: idx}
+				if matches, ok := matchedIndexes[idx]; ok {
+					rank.MatchedIndexes = matches
+				}
+				searchRanks = append(searchRanks, rank)
 			}
 		}
 
 		if trimmed == "" &&
 			(len(m.searchQuery.Tags) > 0 || len(m.searchQuery.Metadata) > 0) {
-			return highlightRanks
+			return searchRanks
+		}
+
+		if trimmed != "" && len(searchRanks) > 0 {
+			ordered := make([]list.Rank, 0, len(searchRanks)+len(baseRanks))
+			seen := make(map[int]struct{}, len(searchRanks))
+			for _, rank := range searchRanks {
+				ordered = append(ordered, rank)
+				seen[rank.Index] = struct{}{}
+			}
+			for _, rank := range baseRanks {
+				if _, ok := seen[rank.Index]; ok {
+					continue
+				}
+				ordered = append(ordered, rank)
+			}
+			return ordered
 		}
 
 		existing := make(map[int]struct{}, len(baseRanks))
@@ -372,7 +398,7 @@ func (m *NoteListModel) makeFilterFunc() list.FilterFunc {
 			existing[rank.Index] = struct{}{}
 		}
 
-		for _, rank := range highlightRanks {
+		for _, rank := range searchRanks {
 			if _, ok := existing[rank.Index]; !ok {
 				baseRanks = append(baseRanks, rank)
 			}
@@ -483,7 +509,22 @@ func (m NoteListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		h, v := appStyle.GetFrameSize()
-		m.list.SetSize(msg.Width-h, msg.Height-v)
+		contentWidth := msg.Width - h
+		if contentWidth < 0 {
+			contentWidth = 0
+		}
+		contentHeight := msg.Height - v
+		if contentHeight < 0 {
+			contentHeight = 0
+		}
+		listWidth := contentWidth / 2
+		if listWidth <= 0 && contentWidth > 0 {
+			listWidth = contentWidth
+		}
+		previewWidth := contentWidth - listWidth
+		m.listWidth = listWidth
+		m.previewWidth = previewWidth
+		m.list.SetSize(listWidth, contentHeight)
 
 		if m.editor != nil {
 			width, height := m.editorSize()
@@ -543,6 +584,8 @@ func (m NoteListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.list = nl
 	cmds = append(cmds, cmd)
 
+	m.ensureSelectionInBounds()
+
 	if nextSelection := m.currentSelectionPath(); nextSelection != previousSelection {
 		if nextSelection == "" {
 			m.preview = ""
@@ -562,6 +605,18 @@ func (m NoteListModel) currentSelectionPath() string {
 	}
 
 	return ""
+}
+
+func (m *NoteListModel) ensureSelectionInBounds() {
+	visible := m.list.VisibleItems()
+	if len(visible) == 0 {
+		m.list.ResetSelected()
+		return
+	}
+
+	if idx := m.list.Index(); idx >= len(visible) {
+		m.list.ResetSelected()
+	}
 }
 
 func (m NoteListModel) handleCopyUpdate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -1103,7 +1158,15 @@ func (m NoteListModel) View() string {
 		return appStyle.Render(layout)
 	}
 
-	list := listStyle.MaxWidth(m.width / 2).Render(m.list.View())
+	listWidth := m.listPaneWidth()
+	listHeight := m.contentHeight()
+	listBox := lipgloss.NewStyle().
+		Width(listWidth).
+		Height(listHeight).
+		Render(m.list.View())
+	list := listStyle.
+		Width(listWidth).
+		Render(listBox)
 
 	if m.copying {
 		textPrompt := textPromptStyle.Render(
@@ -1138,12 +1201,14 @@ func (m NoteListModel) View() string {
 		return appStyle.Render(layout)
 	}
 
-	preview := previewStyle.Render(
-		lipgloss.NewStyle().
-			Height(m.list.Height()).
-			MaxHeight(m.list.Height()).
-			Render(fmt.Sprintf("%s\n%s", titleStyle.Render("Preview"), m.preview)),
-	)
+	previewWidth := m.previewPaneWidth()
+	previewBox := lipgloss.NewStyle().
+		Width(previewWidth).
+		Height(m.contentHeight()).
+		Render(fmt.Sprintf("%s\n%s", titleStyle.Render("Preview"), m.preview))
+	preview := previewStyle.
+		Width(previewWidth).
+		Render(previewBox)
 
 	layout := lipgloss.JoinHorizontal(lipgloss.Top, list, preview)
 	return appStyle.Render(layout)
@@ -1213,8 +1278,14 @@ func (m *NoteListModel) handlePreview(force bool) tea.Cmd {
 
 	cache := m.cache
 	if cache == nil {
-		width := m.width / 2
-		height := m.list.Height()
+		width := m.previewPaneWidth()
+		height := m.contentHeight()
+		if width <= 0 {
+			width = m.width / 2
+		}
+		if height <= 0 {
+			height = m.list.Height()
+		}
 		return renderPreviewCmd(selectedPath, width, height, nil)
 	}
 
@@ -1235,8 +1306,14 @@ func (m *NoteListModel) handlePreview(force bool) tea.Cmd {
 		}
 	}
 
-	width := m.width / 2
-	height := m.list.Height()
+	width := m.previewPaneWidth()
+	if width <= 0 {
+		width = m.width / 2
+	}
+	height := m.contentHeight()
+	if height <= 0 {
+		height = m.list.Height()
+	}
 
 	return renderPreviewCmd(selectedPath, width, height, cache)
 }
@@ -1282,7 +1359,9 @@ func (m *NoteListModel) refreshItems() tea.Cmd {
 	sortedItems := sortItems(castToListItems(items), m.sortField, m.sortOrder)
 	attachHighlightStore(sortedItems, m.highlights)
 	m.rebuildSearch(files)
-	return m.list.SetItems(sortedItems)
+	cmd := m.list.SetItems(sortedItems)
+	m.ensureSelectionInBounds()
+	return cmd
 }
 
 func (m *NoteListModel) refreshDelegate() {
@@ -1351,6 +1430,60 @@ func (m *NoteListModel) afterExternalEditor() tea.Cmd {
 	}
 
 	return nil
+}
+
+func (m *NoteListModel) contentHeight() int {
+	if h := m.list.Height(); h > 0 {
+		return h
+	}
+	if m.height > 0 {
+		_, v := appStyle.GetFrameSize()
+		content := m.height - v
+		if content < 0 {
+			return 0
+		}
+		return content
+	}
+	return 0
+}
+
+func (m *NoteListModel) listPaneWidth() int {
+	if m.listWidth > 0 {
+		return m.listWidth
+	}
+	if m.width > 0 {
+		h, _ := appStyle.GetFrameSize()
+		content := m.width - h
+		if content < 0 {
+			content = 0
+		}
+		width := content / 2
+		if width <= 0 && content > 0 {
+			width = content
+		}
+		return width
+	}
+	return 0
+}
+
+func (m *NoteListModel) previewPaneWidth() int {
+	if m.previewWidth > 0 {
+		return m.previewWidth
+	}
+	content := 0
+	if m.width > 0 {
+		h, _ := appStyle.GetFrameSize()
+		content = m.width - h
+		if content < 0 {
+			content = 0
+		}
+	}
+	listWidth := m.listPaneWidth()
+	previewWidth := content - listWidth
+	if previewWidth <= 0 && content > 0 {
+		previewWidth = listWidth
+	}
+	return previewWidth
 }
 
 func (m *NoteListModel) toggleTitleBar() {

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -1,9 +1,14 @@
 package notes
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Paintersrp/an/internal/config"
 	"github.com/Paintersrp/an/internal/handler"
@@ -48,6 +53,325 @@ func TestCycleViewOrder(t *testing.T) {
 		if got := model.viewName; got != want {
 			t.Fatalf("step %d: expected view %q, got %q", i+1, want, got)
 		}
+	}
+}
+
+func TestRefreshItemsClampsSelectionWhenListShrinks(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	fileNames := []string{"one.md", "two.md", "three.md"}
+	for _, name := range fileNames {
+		path := filepath.Join(tempDir, name)
+		if err := os.WriteFile(path, []byte("content"), 0o644); err != nil {
+			t.Fatalf("failed to write file %s: %v", name, err)
+		}
+	}
+
+	fileHandler := handler.NewFileHandler(tempDir)
+	ws := &config.Workspace{VaultDir: tempDir}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	viewManager, err := views.NewViewManager(fileHandler, cfg)
+	if err != nil {
+		t.Fatalf("NewViewManager returned error: %v", err)
+	}
+
+	model, err := NewNoteListModel(&state.State{
+		Config:        cfg,
+		Workspace:     ws,
+		WorkspaceName: cfg.CurrentWorkspace,
+		Handler:       fileHandler,
+		ViewManager:   viewManager,
+		Vault:         tempDir,
+	}, "default")
+	if err != nil {
+		t.Fatalf("NewNoteListModel returned error: %v", err)
+	}
+
+	if items := len(model.list.Items()); items != len(fileNames) {
+		t.Fatalf("expected %d items, got %d", len(fileNames), items)
+	}
+
+	model.list.Select(2)
+
+	removed := filepath.Join(tempDir, "three.md")
+	if err := os.Remove(removed); err != nil {
+		t.Fatalf("failed to remove %s: %v", removed, err)
+	}
+
+	if cmd := model.refreshItems(); cmd != nil {
+		t.Fatalf("expected refreshItems command to be nil, got %T", cmd)
+	}
+
+	visible := model.list.VisibleItems()
+	if idx := model.list.Index(); idx < 0 || idx >= len(visible) {
+		t.Fatalf("expected selection to be within bounds, got index %d with %d visible items", idx, len(visible))
+	}
+
+	if _, ok := model.list.SelectedItem().(ListItem); !ok {
+		t.Fatalf("expected a selected item after refreshing list")
+	}
+}
+
+func TestWindowSizeSplitsPaneDimensions(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	fileHandler := handler.NewFileHandler(tempDir)
+	ws := &config.Workspace{VaultDir: tempDir}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	viewManager, err := views.NewViewManager(fileHandler, cfg)
+	if err != nil {
+		t.Fatalf("NewViewManager returned error: %v", err)
+	}
+
+	model, err := NewNoteListModel(&state.State{
+		Config:        cfg,
+		Workspace:     ws,
+		WorkspaceName: cfg.CurrentWorkspace,
+		Handler:       fileHandler,
+		ViewManager:   viewManager,
+		Vault:         tempDir,
+	}, "default")
+	if err != nil {
+		t.Fatalf("NewNoteListModel returned error: %v", err)
+	}
+
+	const (
+		windowWidth  = 120
+		windowHeight = 40
+	)
+
+	teaModel, _ := model.Update(tea.WindowSizeMsg{Width: windowWidth, Height: windowHeight})
+	model = adoptNoteModel(teaModel, model)
+
+	hFrame, vFrame := appStyle.GetFrameSize()
+	contentWidth := windowWidth - hFrame
+	if contentWidth < 0 {
+		contentWidth = 0
+	}
+	expectedListWidth := contentWidth / 2
+	if expectedListWidth <= 0 && contentWidth > 0 {
+		expectedListWidth = contentWidth
+	}
+	expectedPreviewWidth := contentWidth - expectedListWidth
+	contentHeight := windowHeight - vFrame
+	if contentHeight < 0 {
+		contentHeight = 0
+	}
+
+	if got := model.listWidth; got != expectedListWidth {
+		t.Fatalf("listWidth = %d, want %d", got, expectedListWidth)
+	}
+	if got := model.previewWidth; got != expectedPreviewWidth {
+		t.Fatalf("previewWidth = %d, want %d", got, expectedPreviewWidth)
+	}
+	if got := model.list.Height(); got != contentHeight {
+		t.Fatalf("list height = %d, want %d", got, contentHeight)
+	}
+}
+
+func TestSearchFilterIncludesBodyMatches(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	matchingBody := []byte("---\ntitle: Body Note\n---\nthis searchterm appears in the body\n")
+	nonMatching := []byte("---\ntitle: Plain Note\n---\njust other content\n")
+
+	bodyPath := filepath.Join(tempDir, "body.md")
+	otherPath := filepath.Join(tempDir, "other.md")
+	if err := os.WriteFile(bodyPath, matchingBody, 0o644); err != nil {
+		t.Fatalf("failed to write body note: %v", err)
+	}
+	if err := os.WriteFile(otherPath, nonMatching, 0o644); err != nil {
+		t.Fatalf("failed to write other note: %v", err)
+	}
+
+	fileHandler := handler.NewFileHandler(tempDir)
+	ws := &config.Workspace{VaultDir: tempDir, Search: config.SearchConfig{EnableBody: true}}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	viewManager, err := views.NewViewManager(fileHandler, cfg)
+	if err != nil {
+		t.Fatalf("NewViewManager returned error: %v", err)
+	}
+
+	model, err := NewNoteListModel(&state.State{
+		Config:        cfg,
+		Workspace:     ws,
+		WorkspaceName: cfg.CurrentWorkspace,
+		Handler:       fileHandler,
+		ViewManager:   viewManager,
+		Vault:         tempDir,
+	}, "default")
+	if err != nil {
+		t.Fatalf("NewNoteListModel returned error: %v", err)
+	}
+
+	items := model.list.Items()
+	targets := make([]string, len(items))
+	for i, item := range items {
+		targets[i] = item.FilterValue()
+	}
+
+	ranks := model.makeFilterFunc()("searchterm", targets)
+	if len(ranks) == 0 {
+		t.Fatalf("expected at least one rank for body search")
+	}
+
+	found := false
+	for _, rank := range ranks {
+		item, ok := items[rank.Index].(ListItem)
+		if !ok {
+			t.Fatalf("expected ListItem at index %d", rank.Index)
+		}
+		if item.path == bodyPath {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected body note to be included in search results")
+	}
+
+	if res, ok := model.highlights.lookup(bodyPath); !ok {
+		t.Fatalf("expected highlight entry for body note")
+	} else if res.Snippet == "" {
+		t.Fatalf("expected highlight snippet for body match")
+	}
+
+	bodyItem := items[ranks[0].Index].(ListItem)
+	if desc := bodyItem.Description(); !strings.Contains(desc, "searchterm") {
+		t.Fatalf("expected description to include snippet, got %q", desc)
+	}
+}
+
+func TestSearchFilterPrefersSearchRankOrder(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	titleMatch := []byte("---\ntitle: Searchterm Heading\n---\ncontent without repeated term\n")
+	bodyMatch := []byte("---\ntitle: Fresh Body\n---\nsearchterm appears multiple times: searchterm searchterm\n")
+
+	titlePath := filepath.Join(tempDir, "title.md")
+	bodyPath := filepath.Join(tempDir, "body.md")
+	if err := os.WriteFile(titlePath, titleMatch, 0o644); err != nil {
+		t.Fatalf("failed to write title note: %v", err)
+	}
+	if err := os.WriteFile(bodyPath, bodyMatch, 0o644); err != nil {
+		t.Fatalf("failed to write body note: %v", err)
+	}
+
+	stale := time.Now().Add(-48 * time.Hour)
+	fresh := time.Now()
+	if err := os.Chtimes(titlePath, stale, stale); err != nil {
+		t.Fatalf("failed to age title note: %v", err)
+	}
+	if err := os.Chtimes(bodyPath, fresh, fresh); err != nil {
+		t.Fatalf("failed to refresh body note time: %v", err)
+	}
+
+	fileHandler := handler.NewFileHandler(tempDir)
+	ws := &config.Workspace{VaultDir: tempDir, Search: config.SearchConfig{EnableBody: true}}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"default": ws},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	viewManager, err := views.NewViewManager(fileHandler, cfg)
+	if err != nil {
+		t.Fatalf("NewViewManager returned error: %v", err)
+	}
+
+	model, err := NewNoteListModel(&state.State{
+		Config:        cfg,
+		Workspace:     ws,
+		WorkspaceName: cfg.CurrentWorkspace,
+		Handler:       fileHandler,
+		ViewManager:   viewManager,
+		Vault:         tempDir,
+	}, "default")
+	if err != nil {
+		t.Fatalf("NewNoteListModel returned error: %v", err)
+	}
+
+	items := model.list.Items()
+	targets := make([]string, len(items))
+	for i, item := range items {
+		targets[i] = item.FilterValue()
+	}
+
+	ranks := model.makeFilterFunc()("searchterm", targets)
+	if len(ranks) < 2 {
+		t.Fatalf("expected both notes to appear in results, got %d", len(ranks))
+	}
+
+	first := items[ranks[0].Index].(ListItem)
+	second := items[ranks[1].Index].(ListItem)
+
+	if first.path != bodyPath {
+		t.Fatalf("expected body match to rank first, got %s", first.path)
+	}
+	if second.path != titlePath {
+		t.Fatalf("expected title match second, got %s", second.path)
+	}
+}
+
+func TestEnsureSelectionInBoundsResetsOutOfRangeCursor(t *testing.T) {
+	t.Parallel()
+
+	delegate := list.NewDefaultDelegate()
+	items := []list.Item{
+		ListItem{fileName: "one.md", path: "one"},
+		ListItem{fileName: "two.md", path: "two"},
+		ListItem{fileName: "three.md", path: "three"},
+	}
+
+	l := list.New(items, delegate, 0, 0)
+	l.SetSize(80, 30)
+	l.Select(2)
+
+	model := &NoteListModel{list: l}
+
+	reduced := []list.Item{items[0]}
+	model.list.SetItems(reduced)
+
+	if idx := model.list.Index(); idx == 0 {
+		t.Fatalf("expected index to remain out of bounds before enforcing selection, got %d", idx)
+	}
+
+	model.ensureSelectionInBounds()
+
+	if idx := model.list.Index(); idx != 0 {
+		t.Fatalf("expected index to reset to 0, got %d", idx)
+	}
+
+	if _, ok := model.list.SelectedItem().(ListItem); !ok {
+		t.Fatalf("expected a selected item after resetting selection")
 	}
 }
 


### PR DESCRIPTION
## Summary
- store the split pane widths when the window is resized so the list and preview keep consistent dimensions
- render the list and preview panes with explicit width/height padding and reuse those dimensions when drawing previews
- add a regression test that verifies the window resize logic populates the expected pane widths and height

## Testing
- go test ./internal/tui/notes
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4660f750c8325ae0c27dc5257768f