### PR TITLE
Ensure filtered note views refresh after state changes

### DIFF
--- a/internal/tui/notes/delegate.go
+++ b/internal/tui/notes/delegate.go
@@ -12,6 +12,8 @@ import (
 
 var currView string
 
+type noteListRefreshMsg struct{}
+
 func newItemDelegate(
 	keys *delegateKeyMap,
 	h *handler.FileHandler,
@@ -44,9 +46,7 @@ func newItemDelegate(
 					if err := h.Archive(p); err != nil {
 						return m.NewStatusMessage(statusStyle("Failed to archive " + n))
 					}
-					i := m.Index()
-					m.RemoveItem(i)
-					return m.NewStatusMessage(statusStyle("Archived " + n))
+					return batchStatusWithRemoval(m, p, statusStyle("Archived "+n))
 				}
 
 			case key.Matches(msg, keys.delete):
@@ -54,18 +54,14 @@ func newItemDelegate(
 					if err := os.Remove(p); err != nil {
 						return m.NewStatusMessage(statusStyle("Failed to delete " + n))
 					}
-					i := m.Index()
-					m.RemoveItem(i)
-					return m.NewStatusMessage(statusStyle("Deleted " + n))
+					return batchStatusWithRemoval(m, p, statusStyle("Deleted "+n))
 				}
 
 			case key.Matches(msg, keys.trash):
 				if err := h.Trash(p); err != nil {
 					return m.NewStatusMessage(statusStyle("Failed to move " + n + " to trash"))
 				}
-				i := m.Index()
-				m.RemoveItem(i)
-				return m.NewStatusMessage(statusStyle("Moved " + n + " to trash"))
+				return batchStatusWithRemoval(m, p, statusStyle("Moved "+n+" to trash"))
 
 			case key.Matches(msg, keys.undo):
 				switch currView {
@@ -73,17 +69,13 @@ func newItemDelegate(
 					if err := h.Unarchive(p); err != nil {
 						return m.NewStatusMessage(statusStyle("Failed to unarchive " + n))
 					}
-					i := m.Index()
-					m.RemoveItem(i)
-					return m.NewStatusMessage(statusStyle("Restored " + n))
+					return batchStatusWithRemoval(m, p, statusStyle("Restored "+n))
 
 				case "trash":
 					if err := h.Untrash(p); err != nil {
 						return m.NewStatusMessage(statusStyle("Failed to restore " + n))
 					}
-					i := m.Index()
-					m.RemoveItem(i)
-					return m.NewStatusMessage(statusStyle("Restored " + n))
+					return batchStatusWithRemoval(m, p, statusStyle("Restored "+n))
 				}
 
 			case key.Matches(msg, keys.keypadDelete):
@@ -92,17 +84,13 @@ func newItemDelegate(
 					if err := h.Trash(p); err != nil {
 						return m.NewStatusMessage(statusStyle("Failed to move " + n + " to trash"))
 					}
-					i := m.Index()
-					m.RemoveItem(i)
-					return m.NewStatusMessage(statusStyle("Moved " + n + " to trash"))
+					return batchStatusWithRemoval(m, p, statusStyle("Moved "+n+" to trash"))
 
 				case "trash":
 					if err := os.Remove(p); err != nil {
 						return m.NewStatusMessage(statusStyle("Failed to delete " + n))
 					}
-					i := m.Index()
-					m.RemoveItem(i)
-					return m.NewStatusMessage(statusStyle("Deleted " + n))
+					return batchStatusWithRemoval(m, p, statusStyle("Deleted "+n))
 				}
 
 			}
@@ -139,6 +127,59 @@ func newItemDelegate(
 		return longHelp
 	}
 	return d
+}
+
+func batchStatusWithRemoval(m *list.Model, path, status string) tea.Cmd {
+	removeCmd := removeItemByPath(m, path)
+	statusCmd := m.NewStatusMessage(status)
+
+	return batchCmds(removeCmd, statusCmd, requestListRefresh())
+}
+
+func removeItemByPath(m *list.Model, path string) tea.Cmd {
+	if path == "" {
+		return nil
+	}
+
+	items := m.Items()
+	for idx, item := range items {
+		li, ok := item.(ListItem)
+		if !ok {
+			continue
+		}
+		if li.path == path {
+			newItems := make([]list.Item, 0, len(items)-1)
+			newItems = append(newItems, items[:idx]...)
+			newItems = append(newItems, items[idx+1:]...)
+			return m.SetItems(newItems)
+		}
+	}
+
+	return nil
+}
+
+func requestListRefresh() tea.Cmd {
+	return func() tea.Msg {
+		return noteListRefreshMsg{}
+	}
+}
+
+func batchCmds(cmds ...tea.Cmd) tea.Cmd {
+	filtered := make([]tea.Cmd, 0, len(cmds))
+	for _, cmd := range cmds {
+		if cmd != nil {
+			filtered = append(filtered, cmd)
+		}
+	}
+
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0]
+	default:
+		return tea.Batch(filtered...)
+	}
 }
 
 type delegateKeyMap struct {

--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -481,6 +481,9 @@ func (m NoteListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		return m, tea.Batch(cmds...)
 
+	case noteListRefreshMsg:
+		return m, batchCmds(m.refreshItems(), m.handlePreview(true))
+
 	case state.VaultWatcherErrMsg:
 		if msg.Err != nil {
 			m.list.NewStatusMessage(


### PR DESCRIPTION
## Summary
- add a delegate refresh message so note list actions always request a rebuild after file operations
- batch list removal, status, and refresh commands to keep filtered views in sync even after swapping views
- handle the refresh message in the note list model to reload items and preview without waiting for a resize

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4770ab1088325a4b1fbaa3966848f