### PR TITLE
Ensure filtered note views refresh after state changes

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -481,6 +481,9 @@ func (m NoteListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		return m, tea.Batch(cmds...)
 
+	case noteListRefreshMsg:
+		return m, batchCmds(m.refreshItems(), m.handlePreview(true))
+
 	case state.VaultWatcherErrMsg:
 		if msg.Err != nil {
 			m.list.NewStatusMessage(


### PR DESCRIPTION
## Summary
- update the delegate removal helper to mutate the list in-place and avoid returning a SetItems command
- prevent stale removal commands from overwriting the refreshed list after a view switch

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4770ab1088325a4b1fbaa3966848f