### PR TITLE
Ensure note list view clears stale rows when view changes

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -1144,7 +1144,22 @@ func (m NoteListModel) View() string {
 		return appStyle.Render(layout)
 	}
 
-	list := listStyle.MaxWidth(m.width / 2).Render(m.list.View())
+	listWidth := m.list.Width()
+	if listWidth <= 0 {
+		listWidth = m.width / 2
+	}
+
+	listHeight := m.list.Height()
+	if listHeight <= 0 {
+		listHeight = m.height
+	}
+
+	listContent := lipgloss.NewStyle().
+		Width(listWidth).
+		Height(listHeight).
+		Render(m.list.View())
+
+	list := listStyle.Width(listWidth).Render(listContent)
 
 	if m.copying {
 		textPrompt := textPromptStyle.Render(


### PR DESCRIPTION
## Summary
- pad the note list view to its configured dimensions before applying styling so previous rows are overwritten when changing views

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d481d8dc848325a64b0ff4ac3f28ae