### PR TITLE
Pad root view to clear stale lines

### DIFF
--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -27,6 +27,8 @@ type RootModel struct {
 	journal *journaltui.Model
 	active  rootView
 	keys    rootKeyMap
+	width   int
+	height  int
 }
 
 type rootKeyMap struct {
@@ -84,6 +86,8 @@ func (m *RootModel) Init() tea.Cmd {
 func (m *RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
 		m.updateAll(msg)
 		return m, nil
 	case tea.QuitMsg:
@@ -160,7 +164,8 @@ func (m *RootModel) View() string {
 		}
 	}
 
-	return strings.Join(sections, "\n")
+	content := strings.Join(sections, "\n")
+	return padToHeight(content, m.height)
 }
 
 func (m *RootModel) header() string {
@@ -313,6 +318,19 @@ func highlight(view rootView, active rootView, label string) string {
 		return fmt.Sprintf("[%s]", label)
 	}
 	return label
+}
+
+func padToHeight(content string, height int) string {
+	if height <= 0 {
+		return content
+	}
+
+	lines := strings.Count(content, "\n") + 1
+	if lines >= height {
+		return content
+	}
+
+	return content + strings.Repeat("\n", height-lines)
 }
 
 func (m *RootModel) updateAll(msg tea.Msg) {

--- a/internal/tui/notes/root_test.go
+++ b/internal/tui/notes/root_test.go
@@ -134,3 +134,38 @@ func TestRootModelKeepsNotesViewWhenEditorActive(t *testing.T) {
 		t.Fatalf("expected editor to capture input, got %q", got)
 	}
 }
+
+func TestRootViewPadsToHeight(t *testing.T) {
+	root := &RootModel{active: viewNotes}
+	root.height = 5
+
+	view := root.View()
+	lines := strings.Count(view, "\n") + 1
+
+	if lines < 5 {
+		t.Fatalf("expected view to render at least 5 lines, got %d", lines)
+	}
+}
+
+func TestPadToHeight(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		height  int
+		expect  int
+	}{
+		{name: "no padding when tall", content: "a\nb\nc", height: 2, expect: 3},
+		{name: "pads shorter content", content: "a\nb", height: 5, expect: 5},
+		{name: "handles empty", content: "", height: 3, expect: 3},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := padToHeight(tc.content, tc.height)
+			lines := strings.Count(got, "\n") + 1
+			if lines != tc.expect {
+				t.Fatalf("expected %d lines, got %d", tc.expect, lines)
+			}
+		})
+	}
+}

--- a/internal/tui/settings/list.go
+++ b/internal/tui/settings/list.go
@@ -195,7 +195,9 @@ func (m ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				index := m.list.Index()
 				items := m.list.Items()
 				items[index] = ListItem{title: "Editor", description: c}
-				m.list.SetItems(items)
+				if cmd := m.list.SetItems(items); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
 				m.list.NewStatusMessage(statusMessageStyle("Updated and Saved: Editor"))
 
 				editorSel := selection.New(
@@ -241,7 +243,9 @@ func (m ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				index := m.list.Index()
 				items := m.list.Items()
 				items[index] = ListItem{title: "FileSystemMode", description: c}
-				m.list.SetItems(items)
+				if cmd := m.list.SetItems(items); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
 				m.list.NewStatusMessage(statusMessageStyle("Updated and Saved: FileSystemMode"))
 
 				modeSel := selection.New(
@@ -339,7 +343,9 @@ func (m ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if updateDescription {
 					items := m.list.Items()
 					items[index] = ListItem{title: title, description: inputValue}
-					m.list.SetItems(items)
+					if cmd := m.list.SetItems(items); cmd != nil {
+						cmds = append(cmds, cmd)
+					}
 				}
 
 				m.configInput.Input.Reset()


### PR DESCRIPTION
## Summary
- track the terminal dimensions in the root model and pad rendered output to the full height
- ensure switching views clears stale rows by adding padding logic that fills remaining lines
- cover the padding behavior with new root view tests

## Testing
- go test ./internal/tui/notes

------
https://chatgpt.com/codex/tasks/task_e_68d4908287b48325afe27d44b4dbdeb4