### PR TITLE
Enhance note preview with related context

### DIFF
--- a/internal/review/graph.go
+++ b/internal/review/graph.go
@@ -24,26 +24,34 @@ func BuildBacklinkGraph(idx *search.Index, seeds []string) Graph {
 
 	visited := make(map[string]struct{})
 	for _, seed := range seeds {
-		if _, ok := visited[seed]; ok {
+		canonical := idx.Canonical(seed)
+		if canonical == "" {
 			continue
 		}
-		visited[seed] = struct{}{}
+		if _, ok := visited[canonical]; ok {
+			continue
+		}
+		visited[canonical] = struct{}{}
 
-		related := idx.Related(seed)
+		related := idx.Related(canonical)
 		node := GraphNode{
-			Path:      seed,
+			Path:      canonical,
 			Outbound:  append([]string(nil), related.Outbound...),
 			Backlinks: append([]string(nil), related.Backlinks...),
 		}
-		graph.Nodes[seed] = node
+		graph.Nodes[canonical] = node
 
 		for _, neighbor := range append(append([]string(nil), node.Outbound...), node.Backlinks...) {
-			if _, ok := graph.Nodes[neighbor]; ok {
+			normalizedNeighbor := idx.Canonical(neighbor)
+			if normalizedNeighbor == "" {
 				continue
 			}
-			relatedNeighbor := idx.Related(neighbor)
-			graph.Nodes[neighbor] = GraphNode{
-				Path:      neighbor,
+			if _, ok := graph.Nodes[normalizedNeighbor]; ok {
+				continue
+			}
+			relatedNeighbor := idx.Related(normalizedNeighbor)
+			graph.Nodes[normalizedNeighbor] = GraphNode{
+				Path:      normalizedNeighbor,
 				Outbound:  append([]string(nil), relatedNeighbor.Outbound...),
 				Backlinks: append([]string(nil), relatedNeighbor.Backlinks...),
 			}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -156,6 +156,29 @@ type RelatedNotes struct {
 	Backlinks []string
 }
 
+// Canonical returns the canonical path for the provided identifier if the
+// document exists in the index. The method resolves aliases and normalizes the
+// resulting path before verifying membership in the index.
+func (idx *Index) Canonical(path string) string {
+	if idx == nil {
+		return ""
+	}
+
+	if resolved := idx.resolveAlias(path); resolved != "" {
+		return resolved
+	}
+
+	normalized := idx.normalize(path)
+	if normalized == "" {
+		return ""
+	}
+
+	if _, ok := idx.docs[normalized]; ok {
+		return normalized
+	}
+	return ""
+}
+
 // Related returns the outbound and backlink relationships for the provided
 // note path. The method accepts absolute or relative paths and falls back to
 // alias matching using the index metadata when possible.

--- a/internal/tui/notes/highlights.go
+++ b/internal/tui/notes/highlights.go
@@ -40,3 +40,19 @@ func (s *highlightStore) lookup(path string) (search.Result, bool) {
 	result, ok := s.matches[path]
 	return result, ok
 }
+
+func (s *highlightStore) related(path string) (search.RelatedNotes, bool) {
+	res, ok := s.lookup(path)
+	if !ok {
+		return search.RelatedNotes{}, false
+	}
+
+	related := search.RelatedNotes{}
+	if len(res.Related.Outbound) > 0 {
+		related.Outbound = append([]string(nil), res.Related.Outbound...)
+	}
+	if len(res.Related.Backlinks) > 0 {
+		related.Backlinks = append([]string(nil), res.Related.Backlinks...)
+	}
+	return related, true
+}

--- a/internal/tui/notes/preview.go
+++ b/internal/tui/notes/preview.go
@@ -1,0 +1,218 @@
+package notes
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Paintersrp/an/internal/pathutil"
+	"github.com/Paintersrp/an/internal/review"
+	"github.com/Paintersrp/an/internal/search"
+)
+
+type previewContext struct {
+	Path            string
+	Outbound        []string
+	Backlinks       []string
+	QueueNeighbours []string
+}
+
+const maxContextItems = 8
+
+func buildPreviewContext(
+	path string,
+	idx *search.Index,
+	queue []string,
+	override *search.RelatedNotes,
+) previewContext {
+	ctx := previewContext{}
+	canonical := canonicalPath(idx, path)
+	ctx.Path = canonical
+
+	if override != nil {
+		ctx.Outbound = copyStrings(override.Outbound)
+		ctx.Backlinks = copyStrings(override.Backlinks)
+	} else if idx != nil {
+		related := idx.Related(canonical)
+		ctx.Outbound = copyStrings(related.Outbound)
+		ctx.Backlinks = copyStrings(related.Backlinks)
+	}
+
+	if len(queue) > 0 && idx != nil {
+		seeds, queueSet := canonicalQueue(queue, idx)
+		if len(seeds) > 0 {
+			graph := review.BuildBacklinkGraph(idx, seeds)
+			matches := queueNeighbours(graph, canonical, queueSet)
+			if len(matches) > 0 {
+				ctx.QueueNeighbours = matches
+			}
+		}
+	}
+
+	return ctx
+}
+
+func formatPreviewContext(ctx previewContext, vault string) string {
+	summary := fmt.Sprintf(
+		"Links: %d outbound · %d backlinks",
+		len(ctx.Outbound),
+		len(ctx.Backlinks),
+	)
+	if len(ctx.QueueNeighbours) > 0 {
+		summary = fmt.Sprintf(
+			"%s · %d queue neighbours",
+			summary,
+			len(ctx.QueueNeighbours),
+		)
+	}
+
+	sections := []struct {
+		title string
+		items []string
+	}{
+		{title: "Outbound", items: ctx.Outbound},
+		{title: "Backlinks", items: ctx.Backlinks},
+	}
+	if len(ctx.QueueNeighbours) > 0 {
+		sections = append(sections, struct {
+			title string
+			items []string
+		}{title: "Queue neighbours", items: ctx.QueueNeighbours})
+	}
+
+	var builder strings.Builder
+	builder.WriteString(summary)
+
+	for _, section := range sections {
+		if len(section.items) == 0 {
+			continue
+		}
+
+		builder.WriteString("\n")
+		builder.WriteString(section.title)
+		builder.WriteString(":\n")
+
+		display := displayPaths(section.items, vault)
+		shown, hidden := limitItems(display, len(section.items), maxContextItems)
+		for _, item := range shown {
+			builder.WriteString("  • ")
+			builder.WriteString(item)
+			builder.WriteString("\n")
+		}
+		if hidden > 0 {
+			builder.WriteString(fmt.Sprintf("  • … and %d more\n", hidden))
+		}
+	}
+
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func canonicalPath(idx *search.Index, path string) string {
+	cleaned := pathutil.NormalizePath(path)
+	if idx == nil {
+		return cleaned
+	}
+	if resolved := idx.Canonical(cleaned); resolved != "" {
+		return resolved
+	}
+	return cleaned
+}
+
+func canonicalQueue(queue []string, idx *search.Index) ([]string, map[string]struct{}) {
+	if len(queue) == 0 {
+		return nil, nil
+	}
+
+	set := make(map[string]struct{}, len(queue))
+	seeds := make([]string, 0, len(queue))
+	for _, candidate := range queue {
+		cleaned := canonicalPath(idx, candidate)
+		if cleaned == "" {
+			continue
+		}
+		if _, ok := set[cleaned]; ok {
+			continue
+		}
+		set[cleaned] = struct{}{}
+		seeds = append(seeds, cleaned)
+	}
+	sort.Strings(seeds)
+	return seeds, set
+}
+
+func queueNeighbours(
+	graph review.Graph,
+	path string,
+	queueSet map[string]struct{},
+) []string {
+	if len(graph.Nodes) == 0 || len(queueSet) == 0 {
+		return nil
+	}
+
+	node, ok := graph.Nodes[path]
+	if !ok {
+		return nil
+	}
+
+	matches := make(map[string]struct{})
+	for _, candidate := range append(copyStrings(node.Outbound), node.Backlinks...) {
+		if _, ok := queueSet[candidate]; ok {
+			matches[candidate] = struct{}{}
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(matches))
+	for candidate := range matches {
+		out = append(out, candidate)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func copyStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, len(values))
+	copy(out, values)
+	return out
+}
+
+func limitItems(items []string, originalCount, limit int) ([]string, int) {
+	if limit <= 0 || len(items) <= limit {
+		return copyStrings(items), originalCount - len(items)
+	}
+	shown := make([]string, limit)
+	copy(shown, items[:limit])
+	return shown, originalCount - limit
+}
+
+func displayPaths(paths []string, vault string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, displayPath(p, vault))
+	}
+	return out
+}
+
+func displayPath(path, vault string) string {
+	cleaned := pathutil.NormalizePath(path)
+	if vault != "" {
+		if rel, err := pathutil.VaultRelative(vault, cleaned); err == nil {
+			rel = strings.TrimPrefix(rel, "./")
+			if rel != "" && rel != "." {
+				return rel
+			}
+		}
+	}
+	base := filepath.Base(cleaned)
+	return filepath.ToSlash(base)
+}

--- a/internal/tui/notes/preview_test.go
+++ b/internal/tui/notes/preview_test.go
@@ -1,0 +1,79 @@
+package notes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/search"
+)
+
+func TestFormatPreviewContextEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx := previewContext{}
+	got := formatPreviewContext(ctx, "")
+	want := "Links: 0 outbound · 0 backlinks"
+	if got != want {
+		t.Fatalf("unexpected summary: got %q, want %q", got, want)
+	}
+}
+
+func TestFormatPreviewContextLargeList(t *testing.T) {
+	t.Parallel()
+
+	ctx := previewContext{
+		Outbound: []string{"one", "two", "three", "four", "five", "six", "seven", "eight", "nine"},
+	}
+
+	summary := formatPreviewContext(ctx, "")
+	if !strings.Contains(summary, "Links: 9 outbound · 0 backlinks") {
+		t.Fatalf("summary missing counts: %q", summary)
+	}
+	if !strings.Contains(summary, "one") || !strings.Contains(summary, "eight") {
+		t.Fatalf("expected early entries to be listed: %q", summary)
+	}
+	if strings.Contains(summary, "nine") {
+		t.Fatalf("expected trailing entries to be truncated: %q", summary)
+	}
+	if !strings.Contains(summary, "… and 1 more") {
+		t.Fatalf("expected truncation notice, got %q", summary)
+	}
+}
+
+func TestBuildPreviewContextResolvesAlias(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	alpha := filepath.Join(tempDir, "Alpha.md")
+	bravo := filepath.Join(tempDir, "bravo.md")
+
+	if err := os.WriteFile(alpha, []byte("[[Bravo]]"), 0o644); err != nil {
+		t.Fatalf("failed to write alpha note: %v", err)
+	}
+	if err := os.WriteFile(bravo, []byte("content"), 0o644); err != nil {
+		t.Fatalf("failed to write bravo note: %v", err)
+	}
+
+	idx := search.NewIndex(tempDir, search.Config{})
+	if err := idx.Build([]string{alpha, bravo}); err != nil {
+		t.Fatalf("build index: %v", err)
+	}
+
+	ctx := buildPreviewContext("Bravo", idx, nil, nil)
+	if ctx.Path != filepath.Clean(bravo) {
+		t.Fatalf("expected canonical path %q, got %q", filepath.Clean(bravo), ctx.Path)
+	}
+	if len(ctx.Backlinks) != 1 {
+		t.Fatalf("expected one backlink, got %d", len(ctx.Backlinks))
+	}
+
+	summary := formatPreviewContext(ctx, tempDir)
+	if !strings.Contains(summary, "Alpha.md") {
+		t.Fatalf("expected relative backlink path in summary: %q", summary)
+	}
+	if !strings.Contains(summary, "Links: 0 outbound · 1 backlinks") {
+		t.Fatalf("expected backlink count in summary: %q", summary)
+	}
+}

--- a/internal/tui/notes/styles.go
+++ b/internal/tui/notes/styles.go
@@ -41,6 +41,9 @@ var (
 			Border(lipgloss.NormalBorder(), false, false, false, true).
 			BorderForeground(lipgloss.Color("#334455"))
 
+	previewSummaryStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#94e2d5"))
+
 	textPromptStyle = previewStyle.Copy()
 
 	linkSelectStyle = lipgloss.NewStyle().MarginLeft(1).


### PR DESCRIPTION
## Summary
- enrich the notes preview pane with contextual link summaries derived from the search index
- surface backlink/outbound counts, highlight-derived relationships, and optional review queue neighbours in the TUI
- expose canonical path resolution for reuse and cover edge cases with new unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4ad6dda948325ba5f5dbbc71a415b