### PR TITLE
Adjust notes root window sizing

### DIFF
--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -350,16 +350,42 @@ func padFrame(content string, width, height int) string {
 }
 
 func (m *RootModel) updateAll(msg tea.Msg) {
+	var (
+		adjustedMsg tea.WindowSizeMsg
+		useAdjusted bool
+	)
+	if windowMsg, ok := msg.(tea.WindowSizeMsg); ok {
+		adjustedMsg = windowMsg
+		headerLines := lipgloss.Height(m.header())
+		adjustedMsg.Height = windowMsg.Height - headerLines
+		if adjustedMsg.Height < 0 {
+			adjustedMsg.Height = 0
+		}
+		useAdjusted = true
+	}
+
 	if m.notes != nil {
-		model, _ := m.notes.Update(msg)
+		forward := msg
+		if useAdjusted {
+			forward = adjustedMsg
+		}
+		model, _ := m.notes.Update(forward)
 		m.notes = adoptNoteModel(model, m.notes)
 	}
 	if m.tasks != nil {
-		model, _ := m.tasks.Update(msg)
+		forward := msg
+		if useAdjusted {
+			forward = adjustedMsg
+		}
+		model, _ := m.tasks.Update(forward)
 		m.tasks = adoptTasksModel(model, m.tasks)
 	}
 	if m.journal != nil {
-		model, _ := m.journal.Update(msg)
+		forward := msg
+		if useAdjusted {
+			forward = adjustedMsg
+		}
+		model, _ := m.journal.Update(forward)
 		m.journal = adoptJournalModel(model, m.journal)
 	}
 }

--- a/internal/tui/notes/root_test.go
+++ b/internal/tui/notes/root_test.go
@@ -136,6 +136,34 @@ func TestRootModelKeepsNotesViewWhenEditorActive(t *testing.T) {
 	}
 }
 
+func TestRootModelViewHeightMatchesWindowSize(t *testing.T) {
+	noteModel := newEditorTestModel(t, map[string]string{"note.md": "content"})
+	root := NewRootModel(noteModel, nil, nil)
+	root.Init()
+
+        const height = 12
+
+        root.Update(tea.WindowSizeMsg{Width: 80, Height: height})
+
+	view := root.View()
+	lines := strings.Split(view, "\n")
+
+	if len(lines) != height {
+		t.Fatalf(
+			"expected %d lines in view, got %d (note height %d, note view lines %d):\n%s",
+			height,
+			len(lines),
+			root.notes.height,
+			lipgloss.Height(root.notes.View()),
+			view,
+		)
+	}
+
+	if len(lines) == 0 || !strings.Contains(lines[0], "Views:") {
+		t.Fatalf("expected header to be visible in view, got %q", view)
+	}
+}
+
 func TestRootViewFillsFrame(t *testing.T) {
 	root := &RootModel{active: viewNotes}
 	root.width = 10


### PR DESCRIPTION
## Summary
- adjust the root model to forward a window height reduced by the header before updating child views
- add a regression test to ensure the notes root view renders exactly the requested number of rows

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5c27569c08325b288f973c04eddb9