### PR TITLE
Ensure editor help hint stays within width

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -1520,7 +1520,7 @@ func (m NoteListModel) View() string {
 		sections := []string{
 			titleStyle.Render(m.editor.viewHeader()),
 			m.editor.area.View(),
-			helpStyle.Render(m.editorInstructions()),
+			renderHelpWithinWidth(width, m.editorInstructions()),
 		}
 
 		if msg := m.editor.status; msg != "" {

--- a/internal/tui/notes/styles.go
+++ b/internal/tui/notes/styles.go
@@ -61,3 +61,14 @@ var (
 	helpStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#cba6f7"))
 )
+
+func renderHelpWithinWidth(width int, content string) string {
+	if width <= 0 {
+		return helpStyle.Render(content)
+	}
+
+	return helpStyle.Copy().
+		Width(width).
+		MaxWidth(width).
+		Render(content)
+}


### PR DESCRIPTION
## Summary
- add a helper to render help text constrained to the editor width
- use the width-aware helper when displaying editor instructions to avoid shifting the editor content

## Testing
- go test ./internal/...


------
https://chatgpt.com/codex/tasks/task_e_68d5c83c1e748325b94add6792fcbb46