### PR TITLE
Adjust markdown preview wrapping

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -127,6 +127,11 @@ func FormatFrontmatterAsMarkdown(frontmatter string) string {
 	return strings.Join(formattedLines, "\n\n")
 }
 
+const (
+	defaultWrapWidth       = 80
+	previewHorizontalSpace = 4
+)
+
 func RenderMarkdownPreview(path string, w, h int, cutoff int) (string, bool) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -149,9 +154,14 @@ func RenderMarkdownPreview(path string, w, h int, cutoff int) (string, bool) {
 		renderedContent = "No frontmatter found.\n\n---\n\n\n" + markdown
 	}
 
+	wrapWidth := w - previewHorizontalSpace
+	if wrapWidth <= 0 {
+		wrapWidth = defaultWrapWidth
+	}
+
 	r, _ := glamour.NewTermRenderer(
 		glamour.WithStandardStyle("dracula"),
-		glamour.WithWordWrap(100),
+		glamour.WithWordWrap(wrapWidth),
 		glamour.WithColorProfile(termenv.ANSI256),
 	)
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestRenderMarkdownPreview_AppliesWrapWidth(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "note.md")
+
+	markdown := `---
+title: Example Note
+---
+
+This is a sentence with enough words to require wrapping when rendered into a preview panel.
+`
+
+	if err := os.WriteFile(path, []byte(markdown), 0o600); err != nil {
+		t.Fatalf("failed to write markdown: %v", err)
+	}
+
+	const previewWidth = 20
+
+	rendered, _ := RenderMarkdownPreview(path, previewWidth, 0, 0)
+
+	wrapWidth := previewWidth - previewHorizontalSpace
+	if wrapWidth <= 0 {
+		wrapWidth = defaultWrapWidth
+	}
+
+	for i, line := range strings.Split(rendered, "\n") {
+		trimmed := strings.TrimRight(line, " ")
+		if trimmed == "" {
+			continue
+		}
+
+		if width := lipgloss.Width(trimmed); width > wrapWidth {
+			t.Fatalf("line %d exceeds wrap width: got %d, want <= %d: %q", i, width, wrapWidth, trimmed)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- derive the markdown preview renderer's wrap width from the panel width argument, with a sensible default
- add unit test coverage to verify narrow previews wrap without overflowing lines

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d6fd9d43b48325a994942481daf43b