### PR TITLE
Enable viewport scrolling for note preview

### DIFF
--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -267,6 +267,7 @@ func (m *RootModel) cycleWorkspace() tea.Cmd {
 		newNotes.width = m.notes.width
 		newNotes.height = m.notes.height
 		newNotes.showDetails = m.notes.showDetails
+		newNotes.previewFocused = m.notes.previewFocused
 	}
 
 	newTasks, err := taskstui.NewModel(newState)


### PR DESCRIPTION
## Summary
- add a viewport to the note preview model and keep it sized with the window
- render the preview through the viewport and forward scroll keys while focused
- cover the new preview behaviour with focused unit tests

## Testing
- go test ./internal/tui/notes -count=1

------
https://chatgpt.com/codex/tasks/task_e_68d707d6ee0083258421d24b2873eb7f