### PR TITLE
Add preview focus toggle and update handling

### DIFF
--- a/internal/tui/notes/keys.go
+++ b/internal/tui/notes/keys.go
@@ -61,6 +61,10 @@ func newListKeyMap() *listKeyMap {
 			key.WithKeys("enter"),
 			key.WithHelp("↵", "open"),
 		),
+		toggleFocus: key.NewBinding(
+			key.WithKeys("shift+tab"),
+			key.WithHelp("⇧+tab", "focus preview"),
+		),
 		openNoteInObsidian: key.NewBinding(
 			key.WithKeys("G"),
 			key.WithHelp("G", "open in obsidian"),
@@ -155,6 +159,7 @@ func (m listKeyMap) fullHelp() []key.Binding {
 		m.togglePagination,
 		m.toggleHelpMenu,
 		m.toggleDisplayView,
+		m.toggleFocus,
 		m.openNote,
 		m.editInline,
 		m.quickCapture,

--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -268,6 +268,11 @@ func (m *RootModel) cycleWorkspace() tea.Cmd {
 		newNotes.height = m.notes.height
 		newNotes.showDetails = m.notes.showDetails
 		newNotes.previewFocused = m.notes.previewFocused
+		if newNotes.previewFocused {
+			newNotes.focusPreview()
+		} else {
+			newNotes.blurPreview()
+		}
 	}
 
 	newTasks, err := taskstui.NewModel(newState)


### PR DESCRIPTION
## Summary
- add a Shift+Tab key binding to toggle preview focus and expose it in the help
- route default updates through focus/blur helpers so preview scroll keys only fire when focused
- drive the new shortcut in the notes tests to verify focus changes and scrolling behaviour

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d716cbdc708325a73314951f52b670