### PR TITLE
Switch root view shortcuts to alt+number chords

### DIFF
--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -42,16 +42,16 @@ type rootKeyMap struct {
 func newRootKeyMap() rootKeyMap {
 	return rootKeyMap{
 		notes: key.NewBinding(
-			key.WithKeys("1"),
-			key.WithHelp("1", "notes"),
+			key.WithKeys("alt+1"),
+			key.WithHelp("alt+1", "notes"),
 		),
 		tasks: key.NewBinding(
-			key.WithKeys("2"),
-			key.WithHelp("2", "tasks"),
+			key.WithKeys("alt+2"),
+			key.WithHelp("alt+2", "tasks"),
 		),
 		journal: key.NewBinding(
-			key.WithKeys("3"),
-			key.WithHelp("3", "journal"),
+			key.WithKeys("alt+3"),
+			key.WithHelp("alt+3", "journal"),
 		),
 		next: key.NewBinding(
 			key.WithKeys("ctrl+w"),
@@ -179,9 +179,9 @@ func (m *RootModel) header() string {
 		sections = append(sections, label)
 	}
 	sections = append(sections, "Views:")
-	sections = append(sections, highlight(viewNotes, m.active, "1. Notes"))
-	sections = append(sections, highlight(viewTasks, m.active, "2. Tasks"))
-	sections = append(sections, highlight(viewJournal, m.active, "3. Journal"))
+	sections = append(sections, highlight(viewNotes, m.active, "alt+1 Notes"))
+	sections = append(sections, highlight(viewTasks, m.active, "alt+2 Tasks"))
+	sections = append(sections, highlight(viewJournal, m.active, "alt+3 Journal"))
 	return strings.Join(sections, "  ")
 }
 

--- a/internal/tui/notes/root_test.go
+++ b/internal/tui/notes/root_test.go
@@ -91,21 +91,21 @@ func TestRootModelNavigation(t *testing.T) {
 	root.Init()
 	root.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 
-	if !strings.Contains(root.View(), "[1. Notes]") {
+	if !strings.Contains(root.View(), "[alt+1 Notes]") {
 		t.Fatalf("expected notes view to be active")
 	}
 
-	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}, Alt: true})
 	if root.active != viewTasks {
-		t.Fatalf("expected tasks view after ctrl+2, got %v", root.active)
+		t.Fatalf("expected tasks view after alt+2, got %v", root.active)
 	}
 	if !strings.Contains(root.View(), "Pinned:") {
 		t.Fatalf("expected tasks view to render pinned status")
 	}
 
-	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}, Alt: true})
 	if root.active != viewJournal {
-		t.Fatalf("expected journal view after ctrl+3, got %v", root.active)
+		t.Fatalf("expected journal view after alt+3, got %v", root.active)
 	}
 	if !strings.Contains(root.View(), "Journal") {
 		t.Fatalf("expected journal view content in output")
@@ -141,9 +141,9 @@ func TestRootModelViewHeightMatchesWindowSize(t *testing.T) {
 	root := NewRootModel(noteModel, nil, nil)
 	root.Init()
 
-        const height = 12
+	const height = 12
 
-        root.Update(tea.WindowSizeMsg{Width: 80, Height: height})
+	root.Update(tea.WindowSizeMsg{Width: 80, Height: height})
 
 	view := root.View()
 	lines := strings.Split(view, "\n")


### PR DESCRIPTION
## Summary
- move the notes/tasks/journal root view bindings to alt+number chords and update the header help text
- adjust the root navigation tests to send the new key chords
- verified other key maps to avoid collisions with the new shortcuts

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d71c6ceb808325a73a03f08e1162a9