### PR TITLE
Align preview context summary styling with status banners

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -2069,7 +2069,7 @@ func renderPreviewContent(markdown, summary string) string {
 	content := markdown
 	trimmedContent := strings.TrimSpace(content)
 	if trimmedSummary != "" {
-		renderedSummary := previewSummaryStyle.Render(trimmedSummary)
+		renderedSummary := statusStyle(trimmedSummary)
 		if trimmedContent != "" {
 			return fmt.Sprintf("%s\n\n%s", renderedSummary, content)
 		}

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -83,7 +83,7 @@ func TestPreviewViewportUpdatesOnPreviewLoaded(t *testing.T) {
 		t.Fatalf("expected viewport view to include content")
 	}
 
-	renderedSummary := previewSummaryStyle.Render(strings.TrimSpace(msg.summary))
+	renderedSummary := statusStyle(strings.TrimSpace(msg.summary))
 	if !strings.Contains(body, renderedSummary) {
 		t.Fatalf("expected viewport view to include summary %q, got %q", renderedSummary, body)
 	}

--- a/internal/tui/notes/styles.go
+++ b/internal/tui/notes/styles.go
@@ -17,9 +17,10 @@ var (
 			BorderStyle(lipgloss.NormalBorder()).
 			Padding(0, 1).Width(100)
 
-	statusStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.AdaptiveColor{Light: "#0AF", Dark: "#0AF"}).
-			Render
+	statusBannerStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.AdaptiveColor{Light: "#0AF", Dark: "#0AF"})
+
+	statusStyle = statusBannerStyle.Render
 
 	focusedStyle = lipgloss.NewStyle().
 			Bold(true).
@@ -40,9 +41,6 @@ var (
 			MarginLeft(1).
 			Border(lipgloss.NormalBorder(), false, false, false, true).
 			BorderForeground(lipgloss.Color("#334455"))
-
-	previewSummaryStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#94e2d5"))
 
 	textPromptStyle = previewStyle.Copy()
 


### PR DESCRIPTION
## Summary
- reuse the status banner lipgloss style for preview/context summaries
- render preview summaries through the shared helper to match other status bars

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d7e1f7853083258ba0feeaa2ac8bde