### PR TITLE
style: polish notes root header banner

### DIFF
--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -181,13 +181,15 @@ func (m *RootModel) header() string {
 			}
 			label += fmt.Sprintf(" (%s to switch)", nextKey)
 		}
-		sections = append(sections, label)
+		sections = append(sections, rootHeaderWorkspaceStyle.Render(label))
 	}
-	sections = append(sections, "Views:")
+
+	sections = append(sections, rootHeaderStyle.Render("Views:"))
 	sections = append(sections, highlight(viewNotes, m.active, formatShortcut(m.keys.notes)))
 	sections = append(sections, highlight(viewTasks, m.active, formatShortcut(m.keys.tasks)))
 	sections = append(sections, highlight(viewJournal, m.active, formatShortcut(m.keys.journal)))
-	return strings.Join(sections, "  ")
+
+	return lipgloss.JoinHorizontal(lipgloss.Left, sections...)
 }
 
 func (m *RootModel) handleViewSwitch(msg tea.KeyMsg) bool {
@@ -376,9 +378,9 @@ func (m *RootModel) notifyWorkspaceStatus(message string) {
 
 func highlight(view rootView, active rootView, label string) string {
 	if view == active {
-		return fmt.Sprintf("[%s]", label)
+		return rootHeaderActiveStyle.Render(fmt.Sprintf("[%s]", label))
 	}
-	return label
+	return rootHeaderStyle.Render(label)
 }
 
 func padFrame(content string, width, height int) string {

--- a/internal/tui/notes/styles.go
+++ b/internal/tui/notes/styles.go
@@ -22,6 +22,15 @@ var (
 
 	statusStyle = statusBannerStyle.Render
 
+	rootHeaderStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "#0AF", Dark: "#0AF"}).
+			Padding(0, 1)
+
+	rootHeaderActiveStyle = rootHeaderStyle.Copy().
+				Bold(true)
+
+	rootHeaderWorkspaceStyle = rootHeaderActiveStyle.Copy()
+
 	focusedStyle = lipgloss.NewStyle().
 			Bold(true).
 			Background(lipgloss.Color("#0AF")).


### PR DESCRIPTION
## Summary
- add dedicated lipgloss styles for the root header banner that reuse the accent palette
- refactor the root header rendering to use the new styles and lipgloss helpers for consistent padding and highlighting

## Testing
- go test ./internal/tui/notes

------
https://chatgpt.com/codex/tasks/task_e_68d7ec89c2dc83259d9cc3702e3aeaa6