### PR TITLE
Adjust preview summary styling

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -2069,7 +2069,7 @@ func renderPreviewContent(markdown, summary string) string {
 	content := markdown
 	trimmedContent := strings.TrimSpace(content)
 	if trimmedSummary != "" {
-		renderedSummary := statusStyle(trimmedSummary)
+		renderedSummary := previewSummaryStyle.Render(trimmedSummary)
 		if trimmedContent != "" {
 			return fmt.Sprintf("%s\n\n%s", renderedSummary, content)
 		}

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -83,7 +83,7 @@ func TestPreviewViewportUpdatesOnPreviewLoaded(t *testing.T) {
 		t.Fatalf("expected viewport view to include content")
 	}
 
-	renderedSummary := statusStyle(strings.TrimSpace(msg.summary))
+	renderedSummary := previewSummaryStyle.Render(strings.TrimSpace(msg.summary))
 	if !strings.Contains(body, renderedSummary) {
 		t.Fatalf("expected viewport view to include summary %q, got %q", renderedSummary, body)
 	}

--- a/internal/tui/notes/styles.go
+++ b/internal/tui/notes/styles.go
@@ -20,6 +20,9 @@ var (
 	statusBannerStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.AdaptiveColor{Light: "#0AF", Dark: "#0AF"})
 
+	previewSummaryStyle = statusBannerStyle.Copy().
+				Padding(0, 1)
+
 	statusStyle = statusBannerStyle.Render
 
 	rootHeaderStyle = lipgloss.NewStyle().


### PR DESCRIPTION
## Summary
- add a dedicated preview summary style that matches other banner padding
- render the preview summary using the new style and update tests accordingly

## Testing
- go test ./internal/tui/notes

------
https://chatgpt.com/codex/tasks/task_e_68d7f10da2f08325aaaecc2271e6b396