### PR TITLE
Integrate root status into list headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,9 @@ require (
 	github.com/charmbracelet/glamour v0.7.0
 	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/erikgeiser/promptkit v0.9.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/ktr0731/go-fuzzyfinder v0.8.0
+	github.com/muesli/reflow v0.3.0
 	github.com/muesli/termenv v0.15.2
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
@@ -27,7 +29,6 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell/v2 v2.6.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
@@ -43,7 +44,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/nsf/termbox-go v1.1.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -24,6 +24,11 @@ type State struct {
 	Home          string
 	Vault         string
 	Watcher       *VaultWatcher
+	RootStatus    *RootStatus
+}
+
+type RootStatus struct {
+	Line string
 }
 
 func NewState(workspaceOverride string) (*State, error) {
@@ -75,6 +80,7 @@ func NewState(workspaceOverride string) (*State, error) {
 		Home:          home,
 		Vault:         ws.VaultDir,
 		Watcher:       watcher,
+		RootStatus:    &RootStatus{},
 	}, nil
 }
 

--- a/internal/tui/notes/root_test.go
+++ b/internal/tui/notes/root_test.go
@@ -100,6 +100,23 @@ func TestRootModelNavigation(t *testing.T) {
 	if !strings.Contains(view, "[n Notes]") {
 		t.Fatalf("expected notes view to be active")
 	}
+	if root.notes == nil || root.notes.state == nil || root.notes.state.RootStatus == nil {
+		t.Fatalf("expected root status to be initialized")
+	}
+	statusLine := root.notes.state.RootStatus.Line
+	if statusLine == "" {
+		t.Fatalf("expected non-empty root status line")
+	}
+	lines := strings.Split(view, "\n")
+	if len(lines) == 0 || !strings.Contains(lines[0], "Workspace:") {
+		t.Fatalf("expected workspace status in header, got %q", view)
+	}
+	if !strings.Contains(view, "Workspace:") {
+		t.Fatalf("expected root status line to be rendered in view: %q", view)
+	}
+	if workspaceInTail(lines, 3) {
+		t.Fatalf("expected workspace status to be part of header, got %q", view)
+	}
 
 	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
 	if root.active != viewTasks {
@@ -112,6 +129,16 @@ func TestRootModelNavigation(t *testing.T) {
 	if !strings.Contains(view, "[i Tasks]") {
 		t.Fatalf("expected tasks shortcut to be highlighted in header: %q", view)
 	}
+	lines = strings.Split(view, "\n")
+	if len(lines) == 0 || !strings.Contains(lines[0], "Workspace:") {
+		t.Fatalf("expected workspace status in header for tasks view: %q", view)
+	}
+	if !strings.Contains(view, "Workspace:") {
+		t.Fatalf("expected tasks view to include root status line: %q", view)
+	}
+	if workspaceInTail(lines, 3) {
+		t.Fatalf("expected workspace status to appear with header in tasks view: %q", view)
+	}
 
 	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
 	if root.active != viewJournal {
@@ -123,6 +150,16 @@ func TestRootModelNavigation(t *testing.T) {
 	}
 	if !strings.Contains(view, "[l Journal]") {
 		t.Fatalf("expected journal shortcut to be highlighted in header: %q", view)
+	}
+	lines = strings.Split(view, "\n")
+	if len(lines) == 0 || !strings.Contains(lines[0], "Workspace:") {
+		t.Fatalf("expected workspace status in header for journal view: %q", view)
+	}
+	if !strings.Contains(view, "Workspace:") {
+		t.Fatalf("expected journal view to include root status line: %q", view)
+	}
+	if workspaceInTail(lines, 3) {
+		t.Fatalf("expected workspace status to appear with header in journal view: %q", view)
 	}
 
 	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
@@ -200,6 +237,21 @@ func TestRootViewFillsFrame(t *testing.T) {
 			t.Fatalf("line %d width mismatch: want at least 10, got %d", i, width)
 		}
 	}
+}
+
+func workspaceInTail(lines []string, tail int) bool {
+	if tail <= 0 {
+		tail = 1
+	}
+	if tail > len(lines) {
+		tail = len(lines)
+	}
+	for _, line := range lines[len(lines)-tail:] {
+		if strings.Contains(line, "Workspace:") {
+			return true
+		}
+	}
+	return false
 }
 
 func TestPadFrame(t *testing.T) {


### PR DESCRIPTION
## Summary
- store the shared workspace/view status on state and propagate it from the root header
- display the root status within the note and task list headers while keeping existing layouts intact
- update navigation tests to ensure the workspace status only appears in the primary header

## Testing
- go test ./internal/tui/notes -count=1
- go test ./internal/tui/tasks -count=1

------
https://chatgpt.com/codex/tasks/task_e_68d850cf69a88325b1a5710365cbd763