### PR TITLE
Fold workspace banner into list headers

### DIFF
--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/reflow/truncate"
 
 	"github.com/Paintersrp/an/internal/config"
 	"github.com/Paintersrp/an/internal/handler"
@@ -741,5 +742,35 @@ func TestToggleCopySeedsInputValue(t *testing.T) {
 				t.Fatalf("expected input value %q, got %q", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestRootStatusSuffixTruncatesToAvailableWidth(t *testing.T) {
+	t.Parallel()
+
+	baseLine := "Checkmark – All View"
+	status := "Workspace: Extremely Long Name"
+	gap := "  "
+
+	baseWidth := lipgloss.Width(baseLine)
+	available := 5
+	width := baseWidth + lipgloss.Width(gap) + available
+
+	suffix := rootStatusSuffix(baseLine, width, status, gap)
+	if suffix == "" {
+		t.Fatalf("expected non-empty suffix")
+	}
+
+	want := truncate.StringWithTail(status, uint(available), "")
+	if suffix != want {
+		t.Fatalf("expected suffix %q, got %q", want, suffix)
+	}
+
+	if narrow := rootStatusSuffix(baseLine, baseWidth+lipgloss.Width(gap), status, gap); narrow != "" {
+		t.Fatalf("expected no suffix when width only covers gap, got %q", narrow)
+	}
+
+	if noGap := rootStatusSuffix("", available, status, ""); noGap != want {
+		t.Fatalf("expected suffix %q without gap, got %q", want, noGap)
 	}
 }

--- a/internal/tui/tasks/model.go
+++ b/internal/tui/tasks/model.go
@@ -223,9 +223,23 @@ func (m *Model) View() string {
 		}
 	}
 
+	listWidth := m.list.Width()
+	if listWidth <= 0 {
+		listWidth = m.width
+	}
+
 	view := m.list.View()
 	if root := m.rootStatusLine(); root != "" {
-		view = appendRootStatus(view, m.list.Width(), root)
+		originalTitle := m.list.Title
+		gap := "  "
+		if originalTitle == "" {
+			gap = ""
+		}
+		if suffix := rootStatusSuffix(view, listWidth, root, gap); suffix != "" {
+			m.list.Title = originalTitle + gap + suffix
+			view = m.list.View()
+			m.list.Title = originalTitle
+		}
 	}
 
 	var statuses []string
@@ -252,35 +266,35 @@ func (m *Model) rootStatusLine() string {
 	return m.state.RootStatus.Line
 }
 
-func appendRootStatus(view string, width int, status string) string {
+func rootStatusSuffix(view string, width int, status, gap string) string {
 	if status == "" || width <= 0 {
-		return view
+		return ""
 	}
 
 	lines := strings.Split(view, "\n")
 	if len(lines) == 0 {
-		return view
+		return ""
 	}
 
 	line := lines[0]
 	available := width - lipgloss.Width(line)
 	if available <= 0 {
-		return view
+		return ""
 	}
 
-	const gap = "  "
-	available -= lipgloss.Width(gap)
-	if available <= 0 {
-		return view
+	if gap != "" {
+		available -= lipgloss.Width(gap)
+		if available <= 0 {
+			return ""
+		}
 	}
 
 	trimmed := truncate.StringWithTail(status, uint(available), "")
 	if trimmed == "" {
-		return view
+		return ""
 	}
 
-	lines[0] = line + gap + trimmed
-	return strings.Join(lines, "\n")
+	return trimmed
 }
 
 func (m *Model) handleOpen() (tea.Model, tea.Cmd) {


### PR DESCRIPTION
## Summary
- merge the shared root status into the note and task list headers before rendering so the workspace banner sits alongside the title/sort text
- keep the width-aware truncation by extracting a reusable helper and covering it with a new unit test

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d861761eb4832584dfd6518102b578