### PR TITLE
Remove workspace banner from notes root header

### DIFF
--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -178,24 +178,6 @@ func (m *RootModel) header() string {
 
 func (m *RootModel) statusLine() string {
 	sections := []string{}
-	if name := m.workspaceName(); name != "" {
-		label := fmt.Sprintf("Workspace: [%s]", name)
-		if m.hasMultipleWorkspaces() {
-			nextHelp := m.keys.next.Help()
-			nextKey := strings.TrimSpace(nextHelp.Key)
-			if nextKey == "" {
-				keys := m.keys.next.Keys()
-				if len(keys) > 0 {
-					nextKey = keys[0]
-				} else {
-					nextKey = "ctrl+w"
-				}
-			}
-			label += fmt.Sprintf(" (%s to switch)", nextKey)
-		}
-		sections = append(sections, rootHeaderWorkspaceStyle.Render(label))
-	}
-
 	sections = append(sections, rootHeaderStyle.Render("Views:"))
 	sections = append(sections, highlight(viewNotes, m.active, formatShortcut(m.keys.notes)))
 	sections = append(sections, highlight(viewTasks, m.active, formatShortcut(m.keys.tasks)))

--- a/internal/tui/notes/root_test.go
+++ b/internal/tui/notes/root_test.go
@@ -108,14 +108,11 @@ func TestRootModelNavigation(t *testing.T) {
 		t.Fatalf("expected non-empty root status line")
 	}
 	lines := strings.Split(view, "\n")
-	if len(lines) == 0 || !strings.Contains(lines[0], "Workspace:") {
-		t.Fatalf("expected workspace status in header, got %q", view)
+	if len(lines) == 0 {
+		t.Fatalf("expected view to contain header line, got %q", view)
 	}
-	if !strings.Contains(view, "Workspace:") {
-		t.Fatalf("expected root status line to be rendered in view: %q", view)
-	}
-	if workspaceInTail(lines, 3) {
-		t.Fatalf("expected workspace status to be part of header, got %q", view)
+	if !strings.HasPrefix(lines[0], statusLine) {
+		t.Fatalf("expected header to start with root status line: header=%q status=%q", lines[0], statusLine)
 	}
 
 	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
@@ -130,14 +127,11 @@ func TestRootModelNavigation(t *testing.T) {
 		t.Fatalf("expected tasks shortcut to be highlighted in header: %q", view)
 	}
 	lines = strings.Split(view, "\n")
-	if len(lines) == 0 || !strings.Contains(lines[0], "Workspace:") {
-		t.Fatalf("expected workspace status in header for tasks view: %q", view)
+	if len(lines) == 0 {
+		t.Fatalf("expected view to contain header line, got %q", view)
 	}
-	if !strings.Contains(view, "Workspace:") {
-		t.Fatalf("expected tasks view to include root status line: %q", view)
-	}
-	if workspaceInTail(lines, 3) {
-		t.Fatalf("expected workspace status to appear with header in tasks view: %q", view)
+	if !strings.HasPrefix(lines[0], root.notes.state.RootStatus.Line) {
+		t.Fatalf("expected header to start with root status line for tasks view: header=%q status=%q", lines[0], root.notes.state.RootStatus.Line)
 	}
 
 	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
@@ -152,14 +146,11 @@ func TestRootModelNavigation(t *testing.T) {
 		t.Fatalf("expected journal shortcut to be highlighted in header: %q", view)
 	}
 	lines = strings.Split(view, "\n")
-	if len(lines) == 0 || !strings.Contains(lines[0], "Workspace:") {
-		t.Fatalf("expected workspace status in header for journal view: %q", view)
+	if len(lines) == 0 {
+		t.Fatalf("expected view to contain header line, got %q", view)
 	}
-	if !strings.Contains(view, "Workspace:") {
-		t.Fatalf("expected journal view to include root status line: %q", view)
-	}
-	if workspaceInTail(lines, 3) {
-		t.Fatalf("expected workspace status to appear with header in journal view: %q", view)
+	if !strings.HasPrefix(lines[0], root.notes.state.RootStatus.Line) {
+		t.Fatalf("expected header to start with root status line for journal view: header=%q status=%q", lines[0], root.notes.state.RootStatus.Line)
 	}
 
 	root.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
@@ -237,21 +228,6 @@ func TestRootViewFillsFrame(t *testing.T) {
 			t.Fatalf("line %d width mismatch: want at least 10, got %d", i, width)
 		}
 	}
-}
-
-func workspaceInTail(lines []string, tail int) bool {
-	if tail <= 0 {
-		tail = 1
-	}
-	if tail > len(lines) {
-		tail = len(lines)
-	}
-	for _, line := range lines[len(lines)-tail:] {
-		if strings.Contains(line, "Workspace:") {
-			return true
-		}
-	}
-	return false
 }
 
 func TestPadFrame(t *testing.T) {

--- a/internal/tui/notes/styles.go
+++ b/internal/tui/notes/styles.go
@@ -32,8 +32,6 @@ var (
 	rootHeaderActiveStyle = rootHeaderStyle.Copy().
 				Bold(true)
 
-	rootHeaderWorkspaceStyle = rootHeaderActiveStyle.Copy()
-
 	focusedStyle = lipgloss.NewStyle().
 			Bold(true).
 			Background(lipgloss.Color("#0AF")).


### PR DESCRIPTION
## Summary
- remove the workspace banner from the notes root header so only view shortcuts remain
- update root view tests to stop expecting workspace text and verify the status line is propagated
- drop the unused workspace-specific header style

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d865243614832584c95e1603dc4220