### PR TITLE
Hide workspace label from notes header

### DIFF
--- a/internal/tui/notes/root.go
+++ b/internal/tui/notes/root.go
@@ -149,7 +149,10 @@ func (m *RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *RootModel) View() string {
 	header := m.header()
-	sections := []string{header}
+	sections := []string{}
+	if header != "" {
+		sections = append(sections, header)
+	}
 
 	switch m.active {
 	case viewNotes:
@@ -177,11 +180,24 @@ func (m *RootModel) header() string {
 }
 
 func (m *RootModel) statusLine() string {
-	sections := []string{}
-	sections = append(sections, rootHeaderStyle.Render("Views:"))
-	sections = append(sections, highlight(viewNotes, m.active, formatShortcut(m.keys.notes)))
-	sections = append(sections, highlight(viewTasks, m.active, formatShortcut(m.keys.tasks)))
-	sections = append(sections, highlight(viewJournal, m.active, formatShortcut(m.keys.journal)))
+	entries := []string{}
+
+	if m.notes != nil {
+		entries = append(entries, highlight(viewNotes, m.active, formatShortcut(m.keys.notes)))
+	}
+	if m.tasks != nil {
+		entries = append(entries, highlight(viewTasks, m.active, formatShortcut(m.keys.tasks)))
+	}
+	if m.journal != nil {
+		entries = append(entries, highlight(viewJournal, m.active, formatShortcut(m.keys.journal)))
+	}
+
+	if len(entries) == 0 {
+		return ""
+	}
+
+	sections := []string{rootHeaderStyle.Render("Views:")}
+	sections = append(sections, entries...)
 
 	return lipgloss.JoinHorizontal(lipgloss.Left, sections...)
 }

--- a/internal/tui/notes/root_test.go
+++ b/internal/tui/notes/root_test.go
@@ -230,6 +230,30 @@ func TestRootViewFillsFrame(t *testing.T) {
 	}
 }
 
+func TestRootHeaderOmittedWhenNoViews(t *testing.T) {
+	st := &state.State{RootStatus: &state.RootStatus{}}
+	root := &RootModel{state: st}
+	root.width = 8
+	root.height = 2
+
+	view := root.View()
+	lines := strings.Split(view, "\n")
+
+	if len(lines) != root.height {
+		t.Fatalf("expected %d lines, got %d", root.height, len(lines))
+	}
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			t.Fatalf("expected blank lines when header and content are empty, got %q", line)
+		}
+	}
+
+	if st.RootStatus.Line != "" {
+		t.Fatalf("expected root status line to be empty, got %q", st.RootStatus.Line)
+	}
+}
+
 func TestPadFrame(t *testing.T) {
 	cases := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- stop rendering the workspace segment in the notes root header and omit the bar when no views are available
- ensure the root status line still updates shared state and cover the empty-header case with tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d8671e216c83258aed53967191d894