### PR TITLE
Align filter palette border with preview panel

### DIFF
--- a/internal/tui/notes/styles.go
+++ b/internal/tui/notes/styles.go
@@ -49,7 +49,7 @@ var (
 
 	filterPaletteStyle = lipgloss.NewStyle().
 				MarginLeft(1).
-				Border(lipgloss.NormalBorder()).
+				Border(lipgloss.NormalBorder(), false, false, false, true).
 				BorderForeground(lipgloss.Color("#334455"))
 
 	linkSelectStyle = lipgloss.NewStyle().MarginLeft(1).


### PR DESCRIPTION
## Summary
- limit the filter palette styling to a single left border so it no longer adds vertical padding

## Testing
- go test ./... *(fails: command hung indefinitely and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d872ac9484832586e4d6e30673e86b