### PR TITLE
Filter out noisy metadata keys from filters

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -514,7 +514,7 @@ func (m *NoteListModel) updateFilterInventory() {
 			}
 			for key, values := range doc.FrontMatter {
 				trimmedKey := strings.TrimSpace(key)
-				if trimmedKey == "" {
+				if trimmedKey == "" || submodels.ShouldExcludeMetadataKey(trimmedKey) {
 					continue
 				}
 				if _, ok := metadataValues[trimmedKey]; !ok {

--- a/internal/tui/notes/submodels/metadata.go
+++ b/internal/tui/notes/submodels/metadata.go
@@ -1,0 +1,20 @@
+package submodels
+
+import "strings"
+
+var excludedMetadataKeys = map[string]struct{}{
+	"created": {},
+	"title":   {},
+}
+
+// ShouldExcludeMetadataKey reports whether the provided metadata key should be
+// hidden from filter inventory and options.
+func ShouldExcludeMetadataKey(key string) bool {
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return false
+	}
+
+	_, excluded := excludedMetadataKeys[strings.ToLower(trimmed)]
+	return excluded
+}


### PR DESCRIPTION
## Summary
- exclude front-matter metadata keys like created/title from the filter inventory
- keep the filter options in sync with the exclusions even when using cached metadata
- add a shared helper to centralize the metadata key exclusion rules

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d8737cff888325a1918e7128588abb