### PR TITLE
Add q shortcut to close note filter

### DIFF
--- a/internal/tui/notes/submodels/filter.go
+++ b/internal/tui/notes/submodels/filter.go
@@ -156,6 +156,8 @@ func (m *FilterModel) Update(msg tea.Msg) (tea.Cmd, bool) {
 		case "k":
 			m.moveCursor(-1)
 			return nil, true
+		case "q":
+			return func() tea.Msg { return FilterClosedMsg{} }, true
 		}
 	}
 
@@ -186,7 +188,7 @@ func (m *FilterModel) View() string {
 		}
 	}
 
-	help := "space toggle • ctrl+l clear • enter close"
+	help := "space toggle • ctrl+l clear • enter/q close"
 	lines = append(lines, "", filterHelpStyle.Render(help))
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary
- allow closing the notes filter overlay with the "q" key
- document the new shortcut in the filter help footer

## Testing
- go run .

------
https://chatgpt.com/codex/tasks/task_e_68d88a158a5483258c5d5b2acb09ba9f