### PR TITLE
Refresh preview after filter changes

### DIFF
--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -712,7 +712,7 @@ func (m *NoteListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.searchQuery.Metadata = cloneMetadataMap(msg.Metadata)
 		m.syncFilterPalette()
 		m.updateFilterStatus()
-		return m, m.applyActiveFilters()
+		return m, batchCmds(m.applyActiveFilters(), m.handlePreview(true))
 
 	case submodels.FilterClosedMsg:
 		m.filtering = false


### PR DESCRIPTION
## Summary
- trigger a preview refresh whenever active filters change in the notes TUI
- add a regression test that ensures filtering updates the preview to the remaining note
- include helper utilities in the tests for draining Bubble Tea commands and normalising preview output

## Testing
- go test ./internal/tui/notes

------
https://chatgpt.com/codex/tasks/task_e_68d898e669748325ade8f04c193c42af