### PR TITLE
Add shared search index service

### DIFF
--- a/internal/services/index/service.go
+++ b/internal/services/index/service.go
@@ -1,0 +1,290 @@
+package index
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Paintersrp/an/internal/pathutil"
+	"github.com/Paintersrp/an/internal/search"
+)
+
+// ErrClosed signals that the index service has been shut down and cannot be
+// used to produce new snapshots.
+var ErrClosed = errors.New("index service closed")
+
+// ErrUnavailable indicates that the search index has not been built yet.
+var ErrUnavailable = errors.New("search index unavailable")
+
+// Stats captures lightweight instrumentation about the shared index.
+type Stats struct {
+	LastRebuild time.Time
+	Pending     int
+}
+
+// Service owns a shared search index for a workspace and coordinates
+// incremental updates coming from the vault watcher.
+type Service struct {
+	mu          sync.RWMutex
+	vault       string
+	config      search.Config
+	index       *search.Index
+	pending     map[string]struct{}
+	lastRebuild time.Time
+	closed      bool
+
+	now    func() time.Time
+	stat   func(string) (fs.FileInfo, error)
+	maxAge time.Duration
+}
+
+// NewService constructs a workspace-scoped index service rooted at the vault.
+func NewService(vault string, cfg search.Config) *Service {
+	normalized := pathutil.NormalizePath(vault)
+	return &Service{
+		vault:   normalized,
+		config:  cfg,
+		pending: make(map[string]struct{}),
+		now:     time.Now,
+		stat:    os.Stat,
+		maxAge:  time.Hour,
+	}
+}
+
+// AcquireSnapshot returns a thread-safe snapshot of the search index. The
+// method rebuilds the index or applies pending updates as needed before cloning
+// the in-memory representation.
+func (s *Service) AcquireSnapshot() (*search.Index, error) {
+	if s == nil {
+		return nil, ErrUnavailable
+	}
+
+	if err := s.ensureFresh(); err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, ErrClosed
+	}
+	if s.index == nil {
+		return nil, ErrUnavailable
+	}
+
+	return s.index.Clone(), nil
+}
+
+// QueueUpdate schedules a relative path for incremental reindexing.
+func (s *Service) QueueUpdate(rel string) {
+	if s == nil {
+		return
+	}
+
+	trimmed := strings.TrimSpace(rel)
+	if trimmed == "" {
+		return
+	}
+
+	normalized := filepath.ToSlash(trimmed)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return
+	}
+	if s.pending == nil {
+		s.pending = make(map[string]struct{})
+	}
+	s.pending[normalized] = struct{}{}
+}
+
+// Stats returns instrumentation about the index lifecycle.
+func (s *Service) Stats() Stats {
+	if s == nil {
+		return Stats{}
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return Stats{LastRebuild: s.lastRebuild, Pending: len(s.pending)}
+}
+
+// Close releases the service. Subsequent calls to AcquireSnapshot will return
+// ErrClosed.
+func (s *Service) Close() error {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	s.index = nil
+	s.pending = nil
+	return nil
+}
+
+func (s *Service) ensureFresh() error {
+	if s == nil {
+		return ErrUnavailable
+	}
+
+	s.mu.RLock()
+	closed := s.closed
+	needsRebuild := s.index == nil
+	if !needsRebuild && s.maxAge > 0 {
+		needsRebuild = s.now().Sub(s.lastRebuild) > s.maxAge
+	}
+	hasPending := len(s.pending) > 0
+	s.mu.RUnlock()
+
+	if closed {
+		return ErrClosed
+	}
+
+	if needsRebuild {
+		if err := s.rebuild(); err != nil {
+			return err
+		}
+	}
+
+	if hasPending {
+		if err := s.applyPending(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) rebuild() error {
+	paths, err := s.collectNotePaths()
+	if err != nil {
+		return err
+	}
+
+	idx := search.NewIndex(s.vault, s.config)
+	if err := idx.Build(paths); err != nil {
+		return fmt.Errorf("build search index: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return ErrClosed
+	}
+
+	s.index = idx
+	s.lastRebuild = s.now()
+	return nil
+}
+
+func (s *Service) applyPending() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return ErrClosed
+	}
+	if s.index == nil {
+		return ErrUnavailable
+	}
+	if len(s.pending) == 0 {
+		return nil
+	}
+
+	idx := s.index
+	pending := s.pending
+	s.pending = make(map[string]struct{})
+
+	for rel := range pending {
+		abs := filepath.Join(s.vault, filepath.FromSlash(rel))
+		normalized := pathutil.NormalizePath(abs)
+		if normalized == "" {
+			continue
+		}
+
+		info, err := s.stat(normalized)
+		switch {
+		case err == nil:
+			if info.IsDir() {
+				if err := idx.Remove(normalized); err != nil {
+					return fmt.Errorf("remove directory %s: %w", normalized, err)
+				}
+				continue
+			}
+			if err := idx.Update(normalized); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					if remErr := idx.Remove(normalized); remErr != nil {
+						return fmt.Errorf("remove missing %s: %w", normalized, remErr)
+					}
+					continue
+				}
+				return fmt.Errorf("update %s: %w", normalized, err)
+			}
+		case errors.Is(err, fs.ErrNotExist):
+			if err := idx.Remove(normalized); err != nil {
+				return fmt.Errorf("remove missing %s: %w", normalized, err)
+			}
+		default:
+			return fmt.Errorf("stat %s: %w", normalized, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) collectNotePaths() ([]string, error) {
+	if s.vault == "" {
+		return nil, errors.New("vault directory cannot be empty")
+	}
+
+	ignored := make(map[string]struct{}, len(s.config.IgnoredFolders))
+	for _, dir := range s.config.IgnoredFolders {
+		ignored[strings.ToLower(dir)] = struct{}{}
+	}
+
+	paths := make([]string, 0)
+	err := filepath.WalkDir(s.vault, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			name := strings.ToLower(d.Name())
+			if strings.HasPrefix(name, ".") && path != s.vault {
+				return filepath.SkipDir
+			}
+			if _, skip := ignored[name]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if strings.EqualFold(filepath.Ext(d.Name()), ".md") {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(paths)
+	return paths, nil
+}

--- a/internal/services/index/service_test.go
+++ b/internal/services/index/service_test.go
@@ -1,0 +1,78 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Paintersrp/an/internal/search"
+)
+
+func writeTestNote(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func TestServiceAcquireSnapshotAppliesPendingUpdates(t *testing.T) {
+	dir := t.TempDir()
+	note := writeTestNote(t, dir, "note.md", "---\ntitle: First\n---\nOriginal content")
+
+	svc := NewService(dir, search.Config{EnableBody: true})
+	idx, err := svc.AcquireSnapshot()
+	if err != nil {
+		t.Fatalf("AcquireSnapshot returned error: %v", err)
+	}
+	if idx == nil {
+		t.Fatalf("expected snapshot index")
+	}
+
+	results := idx.Search(search.Query{Term: "original"})
+	if len(results) != 1 {
+		t.Fatalf("expected initial content to be indexed, got %+v", results)
+	}
+
+	updated := "---\ntitle: First\n---\nUpdated content"
+	if err := os.WriteFile(note, []byte(updated), 0o644); err != nil {
+		t.Fatalf("rewrite note: %v", err)
+	}
+
+	svc.QueueUpdate("note.md")
+	if got := svc.Stats().Pending; got != 1 {
+		t.Fatalf("expected pending queue size 1, got %d", got)
+	}
+
+	idx, err = svc.AcquireSnapshot()
+	if err != nil {
+		t.Fatalf("AcquireSnapshot with pending returned error: %v", err)
+	}
+
+	results = idx.Search(search.Query{Term: "updated"})
+	if len(results) != 1 {
+		t.Fatalf("expected updated content to be indexed, got %+v", results)
+	}
+
+	if got := svc.Stats().Pending; got != 0 {
+		t.Fatalf("expected pending queue to be drained, got %d", got)
+	}
+}
+
+func TestServiceClosePreventsSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	_ = writeTestNote(t, dir, "note.md", "content")
+
+	svc := NewService(dir, search.Config{})
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	if _, err := svc.AcquireSnapshot(); err != ErrClosed {
+		t.Fatalf("expected ErrClosed after Close, got %v", err)
+	}
+}

--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -37,44 +37,41 @@ import (
 
 var maxCacheSizeMB int64 = 50
 
-const searchCompactionInterval = time.Hour
-
 type NoteListModel struct {
-	list                list.Model
-	cache               *cache.Cache
-	keys                *listKeyMap
-	delegateKeys        *delegateKeyMap
-	state               *state.State
-	preview             string
-	previewSummary      string
-	previewViewport     viewport.Model
-	viewName            string
-	formModel           submodels.FormModel
-	filterModel         *submodels.FilterModel
-	inputModel          submodels.InputModel
-	width               int
-	height              int
-	previewWidth        int
-	renaming            bool
-	showDetails         bool
-	creating            bool
-	copying             bool
-	filtering           bool
-	editor              *editorSession
-	sortField           sortField
-	sortOrder           sortOrder
-	searchIndex         *search.Index
-	searchQuery         search.Query
-	searchConfig        search.Config
-	lastSearchRebuild   time.Time
-	highlights          *highlightStore
-	pendingIndexUpdates map[string]struct{}
-	reviewQueue         []review.ResurfaceItem
-	availableTags       []string
-	availableMetadata   map[string][]string
-	allItems            []list.Item
-	searchInitialized   bool
-	previewFocused      bool
+	list              list.Model
+	cache             *cache.Cache
+	keys              *listKeyMap
+	delegateKeys      *delegateKeyMap
+	state             *state.State
+	preview           string
+	previewSummary    string
+	previewViewport   viewport.Model
+	viewName          string
+	formModel         submodels.FormModel
+	filterModel       *submodels.FilterModel
+	inputModel        submodels.InputModel
+	width             int
+	height            int
+	previewWidth      int
+	renaming          bool
+	showDetails       bool
+	creating          bool
+	copying           bool
+	filtering         bool
+	editor            *editorSession
+	sortField         sortField
+	sortOrder         sortOrder
+	searchIndex       *search.Index
+	searchQuery       search.Query
+	searchConfig      search.Config
+	highlights        *highlightStore
+	indexedPaths      map[string]struct{}
+	reviewQueue       []review.ResurfaceItem
+	availableTags     []string
+	availableMetadata map[string][]string
+	allItems          []list.Item
+	searchInitialized bool
+	previewFocused    bool
 }
 
 type previewLoadedMsg struct {
@@ -148,25 +145,25 @@ func NewNoteListModel(
 	filterModel := submodels.NewFilterModel()
 
 	m := &NoteListModel{
-		state:               s,
-		cache:               c,
-		list:                l,
-		viewName:            viewName,
-		keys:                lkeys,
-		delegateKeys:        dkeys,
-		inputModel:          i,
-		formModel:           f,
-		filterModel:         filterModel,
-		renaming:            false,
-		creating:            false,
-		copying:             false,
-		filtering:           false,
-		sortField:           sortField,
-		sortOrder:           sortOrder,
-		highlights:          highlightMatches,
-		pendingIndexUpdates: make(map[string]struct{}),
-		availableMetadata:   make(map[string][]string),
-		previewViewport:     viewport.New(0, 0),
+		state:             s,
+		cache:             c,
+		list:              l,
+		viewName:          viewName,
+		keys:              lkeys,
+		delegateKeys:      dkeys,
+		inputModel:        i,
+		formModel:         f,
+		filterModel:       filterModel,
+		renaming:          false,
+		creating:          false,
+		copying:           false,
+		filtering:         false,
+		sortField:         sortField,
+		sortOrder:         sortOrder,
+		highlights:        highlightMatches,
+		indexedPaths:      make(map[string]struct{}),
+		availableMetadata: make(map[string][]string),
+		previewViewport:   viewport.New(0, 0),
 	}
 
 	m.allItems = append([]list.Item(nil), sortedItems...)
@@ -187,16 +184,11 @@ func (m *NoteListModel) rebuildSearch(paths []string) {
 		m.highlights.clear()
 	}
 
-	if m.pendingIndexUpdates == nil {
-		m.pendingIndexUpdates = make(map[string]struct{})
-	}
-
 	if m.state == nil || m.state.Config == nil {
 		m.searchIndex = nil
 		m.searchQuery = search.Query{}
 		m.searchConfig = search.Config{}
-		m.lastSearchRebuild = time.Time{}
-		m.pendingIndexUpdates = make(map[string]struct{})
+		m.indexedPaths = make(map[string]struct{})
 		return
 	}
 
@@ -209,7 +201,8 @@ func (m *NoteListModel) rebuildSearch(paths []string) {
 
 	metadata := cloneMetadataMap(cfg.DefaultMetadataFilters)
 
-	if !m.searchInitialized {
+	configChanged := !configsEqual(m.searchConfig, searchCfg)
+	if !m.searchInitialized || configChanged {
 		m.searchQuery = search.Query{
 			Tags:     cloneStringSlice(cfg.DefaultTagFilters),
 			Metadata: metadata,
@@ -224,120 +217,31 @@ func (m *NoteListModel) rebuildSearch(paths []string) {
 		}
 	}
 
-	forceRebuild := m.searchIndex == nil ||
-		!configsEqual(m.searchConfig, searchCfg) ||
-		time.Since(m.lastSearchRebuild) > searchCompactionInterval
-
-	if forceRebuild {
-		index := search.NewIndex(m.state.Vault, searchCfg)
-		if err := index.Build(paths); err != nil {
-			log.Printf("failed to rebuild search index: %v", err)
-			m.list.NewStatusMessage(
-				statusStyle(fmt.Sprintf("Search index error: %v", err)),
-			)
-			m.searchIndex = nil
-			return
-		}
-
-		m.searchIndex = index
-		m.searchConfig = searchCfg
-		m.lastSearchRebuild = time.Now()
-		m.pendingIndexUpdates = make(map[string]struct{})
-		return
-	}
-
 	m.searchConfig = searchCfg
-	m.applyPendingIndexUpdates()
-	m.pruneIndex(paths)
-}
-
-func (m *NoteListModel) queueIndexUpdate(rel string) {
-	cleaned := strings.TrimSpace(rel)
-	if cleaned == "" {
-		return
-	}
-	if m.pendingIndexUpdates == nil {
-		m.pendingIndexUpdates = make(map[string]struct{})
-	}
-	m.pendingIndexUpdates[filepath.ToSlash(cleaned)] = struct{}{}
-}
-
-func (m *NoteListModel) applyPendingIndexUpdates() {
-	if len(m.pendingIndexUpdates) == 0 || m.searchIndex == nil || m.state == nil {
-		return
-	}
-
-	for rel := range m.pendingIndexUpdates {
-		abs := filepath.Join(m.state.Vault, filepath.FromSlash(rel))
-		normalized := pathutil.NormalizePath(abs)
-		if normalized == "" {
-			continue
-		}
-
-		info, err := os.Stat(normalized)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				if removeErr := m.searchIndex.Remove(normalized); removeErr != nil {
-					log.Printf("failed to remove %s from search index: %v", normalized, removeErr)
-				}
-				continue
-			}
-			log.Printf("stat for %s failed: %v", normalized, err)
-			continue
-		}
-
-		if info.IsDir() {
-			if removeErr := m.searchIndex.Remove(normalized); removeErr != nil {
-				log.Printf("failed to remove directory %s from search index: %v", normalized, removeErr)
-			}
-			continue
-		}
-
-		if err := m.searchIndex.Update(normalized); err != nil {
-			log.Printf("failed to update search index for %s: %v", normalized, err)
-		}
-	}
-
-	m.pendingIndexUpdates = make(map[string]struct{})
-}
-
-func (m *NoteListModel) pruneIndex(paths []string) {
-	if m.searchIndex == nil {
-		return
-	}
-
-	desired := make(map[string]struct{}, len(paths))
+	m.indexedPaths = make(map[string]struct{}, len(paths))
 	for _, p := range paths {
 		normalized := pathutil.NormalizePath(p)
 		if normalized != "" {
-			desired[normalized] = struct{}{}
+			m.indexedPaths[normalized] = struct{}{}
 		}
 	}
 
-	existingMeta := m.searchIndex.Documents()
-	existing := make(map[string]struct{}, len(existingMeta))
-	for _, meta := range existingMeta {
-		normalized := pathutil.NormalizePath(meta.Path)
-		if normalized == "" {
-			continue
-		}
-		existing[normalized] = struct{}{}
-		if _, ok := desired[normalized]; ok {
-			continue
-		}
-		if err := m.searchIndex.Remove(meta.Path); err != nil {
-			log.Printf("failed to remove stale search document %s: %v", meta.Path, err)
-		}
+	if m.state.Index == nil {
+		m.searchIndex = nil
+		return
 	}
 
-	for normalized := range desired {
-		if _, ok := existing[normalized]; ok {
-			continue
-		}
-		if err := m.searchIndex.Update(normalized); err != nil {
-			log.Printf("failed to index new note %s: %v", normalized, err)
-		}
+	index, err := m.state.Index.AcquireSnapshot()
+	if err != nil {
+		log.Printf("failed to load search index: %v", err)
+		m.list.NewStatusMessage(
+			statusStyle(fmt.Sprintf("Search index error: %v", err)),
+		)
+		m.searchIndex = nil
+		return
 	}
+
+	m.searchIndex = index
 }
 
 func configsEqual(a, b search.Config) bool {
@@ -506,6 +410,15 @@ func (m *NoteListModel) updateFilterInventory() {
 
 	if m.searchIndex != nil {
 		for _, doc := range m.searchIndex.Documents() {
+			normalized := pathutil.NormalizePath(doc.Path)
+			if normalized == "" {
+				continue
+			}
+			if len(m.indexedPaths) > 0 {
+				if _, ok := m.indexedPaths[normalized]; !ok {
+					continue
+				}
+			}
 			for _, tag := range doc.Tags {
 				trimmed := strings.TrimSpace(tag)
 				if trimmed == "" {
@@ -755,7 +668,6 @@ func (m *NoteListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case state.VaultNoteChangedMsg:
-		m.queueIndexUpdate(msg.Path)
 		var force bool
 		if m.cache != nil && m.state != nil {
 			abs := filepath.Join(m.state.Vault, filepath.FromSlash(msg.Path))
@@ -1759,14 +1671,11 @@ func Run(s *state.State, views map[string]v.View, viewFlag string) error {
 }
 
 func (m *NoteListModel) closeWatcher() error {
-	if m.state == nil || m.state.Watcher == nil {
+	if m.state == nil {
 		return nil
 	}
 
-	err := m.state.Watcher.Close()
-	m.state.Watcher = nil
-
-	return err
+	return m.state.Close()
 }
 
 func (m *NoteListModel) handlePreview(force bool) tea.Cmd {


### PR DESCRIPTION
## Summary
- add a shared index service that manages incremental rebuilds and exposes safe snapshots
- wire the state watcher and TUI note model to reuse the cached index instead of rebuilding locally
- update review surfaces and CLI to consume the shared index with graceful fallbacks

## Testing
- go test ./internal/search
- go test ./internal/services/index
- go test ./internal/tui/notes
- go test ./internal/tui/review

------
https://chatgpt.com/codex/tasks/task_e_68d937b601f48325bbf814dccbea9539