### PR TITLE
Add confirmation and logging to review completion

### DIFF
--- a/internal/tui/review/model_test.go
+++ b/internal/tui/review/model_test.go
@@ -1,0 +1,177 @@
+package review
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Paintersrp/an/internal/config"
+	reviewsvc "github.com/Paintersrp/an/internal/review"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+func TestCompleteConfirmationCancel(t *testing.T) {
+	t.Helper()
+	tempDir := t.TempDir()
+	st := newTestState(t, tempDir)
+
+	model, err := NewModel(st)
+	if err != nil {
+		t.Fatalf("NewModel returned error: %v", err)
+	}
+
+	model.editor.SetValue("draft response")
+
+	updated, cmd := model.Update(ctrlEnterMsg())
+	if cmd != nil {
+		t.Fatalf("expected no command after first confirmation, got %T", cmd)
+	}
+	m := adoptTestModel(updated)
+	if !m.confirmingSave {
+		t.Fatalf("expected model to enter confirmation state")
+	}
+	if !strings.Contains(m.status, "ctrl+enter") {
+		t.Fatalf("expected confirmation status message, got %q", m.status)
+	}
+
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Fatalf("expected no command after cancel, got %T", cmd)
+	}
+	m = adoptTestModel(updated)
+	if m.confirmingSave {
+		t.Fatalf("expected confirmation to be cleared after cancel")
+	}
+	if !strings.Contains(strings.ToLower(m.status), "canceled") {
+		t.Fatalf("expected cancel status message, got %q", m.status)
+	}
+
+	reviewDir := filepath.Join(tempDir, ".an", "review")
+	if _, err := os.Stat(reviewDir); !os.IsNotExist(err) {
+		entries, err := os.ReadDir(reviewDir)
+		if err != nil {
+			t.Fatalf("failed to inspect review directory: %v", err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected review directory to remain empty on cancel, found %d entries", len(entries))
+		}
+	}
+}
+
+func TestCompleteConfirmationSavesLog(t *testing.T) {
+	tempDir := t.TempDir()
+	st := newTestState(t, tempDir)
+
+	prevOpen := openReviewNote
+	defer func() {
+		openReviewNote = prevOpen
+	}()
+
+	var openedPath string
+	openReviewNote = func(path string, _ bool) error {
+		openedPath = path
+		return nil
+	}
+
+	model, err := NewModel(st)
+	if err != nil {
+		t.Fatalf("NewModel returned error: %v", err)
+	}
+
+	model.editor.SetValue("completed checklist")
+	model.queue = []reviewsvc.ResurfaceItem{
+		{
+			Path:       filepath.Join(tempDir, "atoms", "sample.md"),
+			ModifiedAt: time.Now().Add(-48 * time.Hour),
+			Bucket:     "weekly",
+		},
+	}
+
+	updated, cmd := model.Update(ctrlEnterMsg())
+	if cmd != nil {
+		t.Fatalf("expected no command after first confirmation, got %T", cmd)
+	}
+	m := adoptTestModel(updated)
+
+	updated, cmd = m.Update(ctrlEnterMsg())
+	if cmd == nil {
+		t.Fatal("expected save command after confirmation")
+	}
+	m = adoptTestModel(updated)
+	if status := strings.ToLower(m.status); !strings.Contains(status, "saving") {
+		t.Fatalf("expected saving status, got %q", m.status)
+	}
+
+	msg := cmd()
+	updated, _ = m.Update(msg)
+	m = adoptTestModel(updated)
+
+	if openedPath == "" {
+		t.Fatalf("expected review note to be opened")
+	}
+	if _, err := os.Stat(openedPath); err != nil {
+		t.Fatalf("expected review log to exist: %v", err)
+	}
+	content, err := os.ReadFile(openedPath)
+	if err != nil {
+		t.Fatalf("failed to read review log: %v", err)
+	}
+	if !strings.Contains(string(content), "Checklist responses") {
+		t.Fatalf("expected checklist section in log: %s", string(content))
+	}
+	if !strings.Contains(string(content), "Resurfacing queue") {
+		t.Fatalf("expected queue section in log: %s", string(content))
+	}
+	if !strings.Contains(m.status, filepath.Base(openedPath)) {
+		t.Fatalf("expected status to include saved filename, got %q", m.status)
+	}
+	if m.confirmingSave {
+		t.Fatalf("expected confirmation state to be cleared after save")
+	}
+}
+
+func newTestState(t *testing.T, vault string) *state.State {
+	t.Helper()
+
+	ws := &config.Workspace{
+		VaultDir:       vault,
+		Editor:         "nvim",
+		FileSystemMode: "strict",
+	}
+	cfg := &config.Config{
+		Workspaces:       map[string]*config.Workspace{"test": ws},
+		CurrentWorkspace: "test",
+	}
+	if err := cfg.ActivateWorkspace("test"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	tmpl, err := templater.NewTemplater(ws)
+	if err != nil {
+		t.Fatalf("failed to create templater: %v", err)
+	}
+
+	return &state.State{
+		Config:    cfg,
+		Workspace: ws,
+		Templater: tmpl,
+		Vault:     ws.VaultDir,
+	}
+}
+
+func adoptTestModel(model tea.Model) *Model {
+	m, ok := model.(*Model)
+	if !ok {
+		panic("unexpected model type")
+	}
+	return m
+}
+
+func ctrlEnterMsg() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("ctrl+enter")}
+}

--- a/internal/tui/review/save.go
+++ b/internal/tui/review/save.go
@@ -1,0 +1,212 @@
+package review
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Paintersrp/an/internal/note"
+	reviewsvc "github.com/Paintersrp/an/internal/review"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+var (
+	openReviewNote    = note.OpenFromPath
+	filenameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9\-]+`)
+)
+
+func persistReviewLog(
+	st *state.State,
+	manifest templater.TemplateManifest,
+	responses map[string]string,
+	queue []reviewsvc.ResurfaceItem,
+	ts time.Time,
+) (string, error) {
+	if st == nil {
+		return "", errors.New("state is not configured")
+	}
+
+	vault := strings.TrimSpace(st.Vault)
+	if vault == "" {
+		return "", errors.New("vault directory is not configured")
+	}
+
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	} else {
+		ts = ts.UTC()
+	}
+
+	dir, subdir, err := ensureReviewDir(st)
+	if err != nil {
+		return "", err
+	}
+
+	filename := buildReviewFilename(manifest, ts)
+	noteRef := note.NewZettelkastenNote(vault, subdir, filename, nil, nil, "")
+	if _, err := noteRef.EnsurePath(); err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(dir, filename+".md")
+	content := renderReviewLogContent(manifest, responses, queue, ts, vault)
+	if err := appendReviewLog(path, content); err != nil {
+		return "", err
+	}
+
+	if err := openReviewNote(path, false); err != nil {
+		return "", err
+	}
+
+	return path, nil
+}
+
+func ensureReviewDir(st *state.State) (string, string, error) {
+	vault := strings.TrimSpace(st.Vault)
+	dir := ""
+	if st.Workspace != nil {
+		if path := strings.TrimSpace(st.Workspace.NamedPins["review"]); path != "" {
+			if filepath.IsAbs(path) {
+				dir = path
+			} else {
+				dir = filepath.Join(vault, path)
+			}
+		}
+	}
+	if dir == "" {
+		dir = filepath.Join(vault, ".an", "review")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", "", err
+	}
+
+	rel, err := filepath.Rel(vault, dir)
+	if err != nil {
+		return "", "", err
+	}
+	if strings.HasPrefix(rel, "..") {
+		return "", "", fmt.Errorf("review directory %q must be inside the vault", dir)
+	}
+	rel = filepath.ToSlash(rel)
+	return dir, rel, nil
+}
+
+func buildReviewFilename(manifest templater.TemplateManifest, ts time.Time) string {
+	name := strings.TrimSpace(manifest.Name)
+	if name == "" {
+		name = "review"
+	}
+	name = strings.ToLower(name)
+	name = strings.ReplaceAll(name, " ", "-")
+	name = filenameSanitizer.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	if name == "" {
+		name = "review"
+	}
+	return fmt.Sprintf("%s-%s", name, ts.Format("2006-01-02"))
+}
+
+func renderReviewLogContent(
+	manifest templater.TemplateManifest,
+	responses map[string]string,
+	queue []reviewsvc.ResurfaceItem,
+	ts time.Time,
+	vault string,
+) string {
+	var builder strings.Builder
+
+	title := strings.TrimSpace(manifest.Name)
+	if title == "" {
+		title = "Review"
+	}
+	fmt.Fprintf(&builder, "## %s — %s UTC\n\n", title, ts.Format(time.RFC3339))
+
+	if desc := strings.TrimSpace(manifest.Description); desc != "" {
+		builder.WriteString(desc)
+		builder.WriteString("\n\n")
+	}
+
+	builder.WriteString("### Checklist responses\n\n")
+	if len(manifest.Fields) == 0 {
+		builder.WriteString("- _No checklist steps configured._\n")
+	} else {
+		for _, field := range manifest.Fields {
+			label := strings.TrimSpace(field.Label)
+			if label == "" {
+				label = humanizeKey(field.Key)
+			}
+			response := strings.TrimSpace(responses[field.Key])
+			if response == "" {
+				fmt.Fprintf(&builder, "- **%s:** _(no response)_\n", label)
+				continue
+			}
+			if strings.Contains(response, "\n") {
+				fmt.Fprintf(&builder, "- **%s:**\n", label)
+				lines := strings.Split(response, "\n")
+				for _, line := range lines {
+					if strings.TrimSpace(line) == "" {
+						builder.WriteString("  \n")
+					} else {
+						fmt.Fprintf(&builder, "  %s\n", line)
+					}
+				}
+			} else {
+				fmt.Fprintf(&builder, "- **%s:** %s\n", label, response)
+			}
+		}
+	}
+
+	builder.WriteString("\n### Resurfacing queue\n\n")
+	if len(queue) == 0 {
+		builder.WriteString("- _No resurfacing candidates._\n")
+	} else {
+		for _, item := range queue {
+			path := item.Path
+			if rel, err := filepath.Rel(vault, item.Path); err == nil && !strings.HasPrefix(rel, "..") {
+				path = filepath.ToSlash(rel)
+			}
+			last := item.ModifiedAt.UTC().Format("2006-01-02")
+			bucket := strings.TrimSpace(item.Bucket)
+			if bucket == "" {
+				bucket = "unscheduled"
+			}
+			fmt.Fprintf(&builder, "- %s — last touched %s (%s)\n", path, last, bucket)
+		}
+	}
+
+	builder.WriteString("\n")
+	return builder.String()
+}
+
+func appendReviewLog(path, content string) error {
+	if strings.TrimSpace(content) == "" {
+		return nil
+	}
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	entry := strings.TrimRight(content, "\n") + "\n"
+	if info.Size() > 0 {
+		entry = "\n\n" + entry
+	}
+
+	_, err = file.WriteString(entry)
+	return err
+}


### PR DESCRIPTION
## Summary
- add a confirmation state before completing a review checklist and surface status updates
- persist review sessions into markdown logs using the review templater metadata and open the saved note
- cover ctrl+enter confirmation and cancel flows with unit tests around the review model

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d9669e767c83259b49130e0298cc57