### PR TITLE
Add review log output to CLI review command

### DIFF
--- a/internal/review/log.go
+++ b/internal/review/log.go
@@ -1,0 +1,191 @@
+package review
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+var filenameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9\-]+`)
+
+// EnsureLogDir resolves and creates the directory used for persisted review logs.
+// The configured path may be absolute or relative to the vault. When empty, the
+// default ".an/review" directory inside the vault is used. The resolved
+// directory must live inside the vault.
+func EnsureLogDir(vault, configured string) (string, string, error) {
+	vault = strings.TrimSpace(vault)
+	if vault == "" {
+		return "", "", fmt.Errorf("vault directory is not configured")
+	}
+
+	dir := strings.TrimSpace(configured)
+	if dir == "" {
+		dir = filepath.Join(vault, ".an", "review")
+	} else if !filepath.IsAbs(dir) {
+		dir = filepath.Join(vault, dir)
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", "", err
+	}
+
+	rel, err := filepath.Rel(vault, dir)
+	if err != nil {
+		return "", "", err
+	}
+	if strings.HasPrefix(rel, "..") {
+		return "", "", fmt.Errorf("review directory %q must be inside the vault", dir)
+	}
+	rel = filepath.ToSlash(rel)
+	return dir, rel, nil
+}
+
+// WriteMarkdownLog renders the checklist responses and resurfacing queue to a
+// Markdown log file within the provided directory. The file name is derived
+// from the manifest name and UTC timestamp. The written path is returned.
+func WriteMarkdownLog(
+	dir string,
+	manifest templater.TemplateManifest,
+	responses map[string]string,
+	queue []ResurfaceItem,
+	ts time.Time,
+	vault string,
+) (string, error) {
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	} else {
+		ts = ts.UTC()
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+
+	filename := buildReviewFilename(manifest, ts)
+	path := filepath.Join(dir, filename+".md")
+	content := renderReviewLogContent(manifest, responses, queue, ts, vault)
+	if err := appendReviewLog(path, content); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func buildReviewFilename(manifest templater.TemplateManifest, ts time.Time) string {
+	name := strings.TrimSpace(manifest.Name)
+	if name == "" {
+		name = "review"
+	}
+	name = strings.ToLower(name)
+	name = strings.ReplaceAll(name, " ", "-")
+	name = filenameSanitizer.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	if name == "" {
+		name = "review"
+	}
+	return fmt.Sprintf("%s-%s", name, ts.Format("2006-01-02"))
+}
+
+func renderReviewLogContent(
+	manifest templater.TemplateManifest,
+	responses map[string]string,
+	queue []ResurfaceItem,
+	ts time.Time,
+	vault string,
+) string {
+	var builder strings.Builder
+
+	title := strings.TrimSpace(manifest.Name)
+	if title == "" {
+		title = "Review"
+	}
+	fmt.Fprintf(&builder, "## %s — %s UTC\n\n", title, ts.Format(time.RFC3339))
+
+	if desc := strings.TrimSpace(manifest.Description); desc != "" {
+		builder.WriteString(desc)
+		builder.WriteString("\n\n")
+	}
+
+	builder.WriteString("### Checklist responses\n\n")
+	if len(manifest.Fields) == 0 {
+		builder.WriteString("- _No checklist steps configured._\n")
+	} else {
+		for _, field := range manifest.Fields {
+			label := strings.TrimSpace(field.Label)
+			if label == "" {
+				label = humanizeKey(field.Key)
+			}
+			response := strings.TrimSpace(responses[field.Key])
+			if response == "" {
+				fmt.Fprintf(&builder, "- **%s:** _(no response)_\n", label)
+				continue
+			}
+			if strings.Contains(response, "\n") {
+				fmt.Fprintf(&builder, "- **%s:**\n", label)
+				lines := strings.Split(response, "\n")
+				for _, line := range lines {
+					if strings.TrimSpace(line) == "" {
+						builder.WriteString("  \n")
+					} else {
+						fmt.Fprintf(&builder, "  %s\n", line)
+					}
+				}
+			} else {
+				fmt.Fprintf(&builder, "- **%s:** %s\n", label, response)
+			}
+		}
+	}
+
+	builder.WriteString("\n### Resurfacing queue\n\n")
+	if len(queue) == 0 {
+		builder.WriteString("- _No resurfacing candidates._\n")
+	} else {
+		for _, item := range queue {
+			path := item.Path
+			if rel, err := filepath.Rel(vault, item.Path); err == nil && !strings.HasPrefix(rel, "..") {
+				path = filepath.ToSlash(rel)
+			}
+			last := item.ModifiedAt.UTC().Format("2006-01-02")
+			bucket := strings.TrimSpace(item.Bucket)
+			if bucket == "" {
+				bucket = "unscheduled"
+			}
+			fmt.Fprintf(&builder, "- %s — last touched %s (%s)\n", path, last, bucket)
+		}
+	}
+
+	builder.WriteString("\n")
+	return builder.String()
+}
+
+func appendReviewLog(path, content string) error {
+	if strings.TrimSpace(content) == "" {
+		return nil
+	}
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	entry := strings.TrimRight(content, "\n") + "\n"
+	if info.Size() > 0 {
+		entry = "\n\n" + entry
+	}
+
+	_, err = file.WriteString(entry)
+	return err
+}

--- a/internal/tui/review/save.go
+++ b/internal/tui/review/save.go
@@ -2,10 +2,6 @@ package review
 
 import (
 	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -16,8 +12,7 @@ import (
 )
 
 var (
-	openReviewNote    = note.OpenFromPath
-	filenameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9\-]+`)
+	openReviewNote = note.OpenFromPath
 )
 
 func persistReviewLog(
@@ -42,20 +37,13 @@ func persistReviewLog(
 		ts = ts.UTC()
 	}
 
-	dir, subdir, err := ensureReviewDir(st)
+	dir, _, err := ensureReviewDir(st)
 	if err != nil {
 		return "", err
 	}
 
-	filename := buildReviewFilename(manifest, ts)
-	noteRef := note.NewZettelkastenNote(vault, subdir, filename, nil, nil, "")
-	if _, err := noteRef.EnsurePath(); err != nil {
-		return "", err
-	}
-
-	path := filepath.Join(dir, filename+".md")
-	content := renderReviewLogContent(manifest, responses, queue, ts, vault)
-	if err := appendReviewLog(path, content); err != nil {
+	path, err := reviewsvc.WriteMarkdownLog(dir, manifest, responses, queue, ts, vault)
+	if err != nil {
 		return "", err
 	}
 
@@ -68,145 +56,9 @@ func persistReviewLog(
 
 func ensureReviewDir(st *state.State) (string, string, error) {
 	vault := strings.TrimSpace(st.Vault)
-	dir := ""
+	configured := ""
 	if st.Workspace != nil {
-		if path := strings.TrimSpace(st.Workspace.NamedPins["review"]); path != "" {
-			if filepath.IsAbs(path) {
-				dir = path
-			} else {
-				dir = filepath.Join(vault, path)
-			}
-		}
+		configured = st.Workspace.NamedPins["review"]
 	}
-	if dir == "" {
-		dir = filepath.Join(vault, ".an", "review")
-	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", "", err
-	}
-
-	rel, err := filepath.Rel(vault, dir)
-	if err != nil {
-		return "", "", err
-	}
-	if strings.HasPrefix(rel, "..") {
-		return "", "", fmt.Errorf("review directory %q must be inside the vault", dir)
-	}
-	rel = filepath.ToSlash(rel)
-	return dir, rel, nil
-}
-
-func buildReviewFilename(manifest templater.TemplateManifest, ts time.Time) string {
-	name := strings.TrimSpace(manifest.Name)
-	if name == "" {
-		name = "review"
-	}
-	name = strings.ToLower(name)
-	name = strings.ReplaceAll(name, " ", "-")
-	name = filenameSanitizer.ReplaceAllString(name, "-")
-	name = strings.Trim(name, "-")
-	if name == "" {
-		name = "review"
-	}
-	return fmt.Sprintf("%s-%s", name, ts.Format("2006-01-02"))
-}
-
-func renderReviewLogContent(
-	manifest templater.TemplateManifest,
-	responses map[string]string,
-	queue []reviewsvc.ResurfaceItem,
-	ts time.Time,
-	vault string,
-) string {
-	var builder strings.Builder
-
-	title := strings.TrimSpace(manifest.Name)
-	if title == "" {
-		title = "Review"
-	}
-	fmt.Fprintf(&builder, "## %s — %s UTC\n\n", title, ts.Format(time.RFC3339))
-
-	if desc := strings.TrimSpace(manifest.Description); desc != "" {
-		builder.WriteString(desc)
-		builder.WriteString("\n\n")
-	}
-
-	builder.WriteString("### Checklist responses\n\n")
-	if len(manifest.Fields) == 0 {
-		builder.WriteString("- _No checklist steps configured._\n")
-	} else {
-		for _, field := range manifest.Fields {
-			label := strings.TrimSpace(field.Label)
-			if label == "" {
-				label = humanizeKey(field.Key)
-			}
-			response := strings.TrimSpace(responses[field.Key])
-			if response == "" {
-				fmt.Fprintf(&builder, "- **%s:** _(no response)_\n", label)
-				continue
-			}
-			if strings.Contains(response, "\n") {
-				fmt.Fprintf(&builder, "- **%s:**\n", label)
-				lines := strings.Split(response, "\n")
-				for _, line := range lines {
-					if strings.TrimSpace(line) == "" {
-						builder.WriteString("  \n")
-					} else {
-						fmt.Fprintf(&builder, "  %s\n", line)
-					}
-				}
-			} else {
-				fmt.Fprintf(&builder, "- **%s:** %s\n", label, response)
-			}
-		}
-	}
-
-	builder.WriteString("\n### Resurfacing queue\n\n")
-	if len(queue) == 0 {
-		builder.WriteString("- _No resurfacing candidates._\n")
-	} else {
-		for _, item := range queue {
-			path := item.Path
-			if rel, err := filepath.Rel(vault, item.Path); err == nil && !strings.HasPrefix(rel, "..") {
-				path = filepath.ToSlash(rel)
-			}
-			last := item.ModifiedAt.UTC().Format("2006-01-02")
-			bucket := strings.TrimSpace(item.Bucket)
-			if bucket == "" {
-				bucket = "unscheduled"
-			}
-			fmt.Fprintf(&builder, "- %s — last touched %s (%s)\n", path, last, bucket)
-		}
-	}
-
-	builder.WriteString("\n")
-	return builder.String()
-}
-
-func appendReviewLog(path, content string) error {
-	if strings.TrimSpace(content) == "" {
-		return nil
-	}
-	if !strings.HasSuffix(content, "\n") {
-		content += "\n"
-	}
-
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	info, err := file.Stat()
-	if err != nil {
-		return err
-	}
-
-	entry := strings.TrimRight(content, "\n") + "\n"
-	if info.Size() > 0 {
-		entry = "\n\n" + entry
-	}
-
-	_, err = file.WriteString(entry)
-	return err
+	return reviewsvc.EnsureLogDir(vault, configured)
 }

--- a/pkg/cmd/review/review_test.go
+++ b/pkg/cmd/review/review_test.go
@@ -1,0 +1,163 @@
+package review
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/an/internal/config"
+	"github.com/Paintersrp/an/internal/state"
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+func TestReviewCommand_WritesLog(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	vault := t.TempDir()
+	queueDir := filepath.Join(vault, "logs")
+
+	notes := []struct {
+		name string
+		mod  time.Time
+	}{
+		{name: "first-note.md", mod: time.Date(2022, 3, 14, 9, 0, 0, 0, time.UTC)},
+		{name: "second-note.md", mod: time.Date(2022, 4, 20, 15, 30, 0, 0, time.UTC)},
+	}
+	for _, note := range notes {
+		path := filepath.Join(vault, note.name)
+		if err := os.WriteFile(path, []byte("# Note\n"), 0o644); err != nil {
+			t.Fatalf("failed to write note %q: %v", note.name, err)
+		}
+		if err := os.Chtimes(path, note.mod, note.mod); err != nil {
+			t.Fatalf("failed to set mod time for %q: %v", note.name, err)
+		}
+	}
+
+	cfg := &config.Config{
+		Workspaces: map[string]*config.Workspace{
+			"default": {
+				VaultDir:  vault,
+				NamedPins: config.PinMap{"review": "logs"},
+			},
+		},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	tmpl, err := templater.NewTemplater(cfg.MustWorkspace())
+	if err != nil {
+		t.Fatalf("failed to create templater: %v", err)
+	}
+
+	st := &state.State{Config: cfg, Workspace: cfg.MustWorkspace(), WorkspaceName: cfg.CurrentWorkspace, Templater: tmpl, Vault: vault}
+
+	cmd := NewCmdReview(st)
+	cmd.SetArgs([]string{})
+	cmd.SetIn(strings.NewReader("inbox cleared\nfocus planned\ntasks reviewed\n"))
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("review command returned error: %v\noutput: %s", err, output.String())
+	}
+
+	entries, err := os.ReadDir(queueDir)
+	if err != nil {
+		t.Fatalf("failed to read log directory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log file, found %d", len(entries))
+	}
+
+	logPath := filepath.Join(queueDir, entries[0].Name())
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	logStr := string(content)
+
+	if !strings.Contains(logStr, "### Checklist responses") {
+		t.Fatalf("log file missing checklist heading: %s", logStr)
+	}
+	if !strings.Contains(logStr, "- **Clear capture inbox:** inbox cleared") {
+		t.Fatalf("log file missing first response: %s", logStr)
+	}
+	if !strings.Contains(logStr, "- **Plan focus blocks:** focus planned") {
+		t.Fatalf("log file missing second response: %s", logStr)
+	}
+	if !strings.Contains(logStr, "- **Sweep lingering todos:** tasks reviewed") {
+		t.Fatalf("log file missing third response: %s", logStr)
+	}
+	if !strings.Contains(logStr, "### Resurfacing queue") {
+		t.Fatalf("log file missing queue heading: %s", logStr)
+	}
+	if !strings.Contains(logStr, "first-note.md — last touched 2022-03-14") {
+		t.Fatalf("log file missing first queue entry: %s", logStr)
+	}
+	if !strings.Contains(logStr, "second-note.md — last touched 2022-04-20") {
+		t.Fatalf("log file missing second queue entry: %s", logStr)
+	}
+	if !strings.Contains(output.String(), "Review log saved:") {
+		t.Fatalf("expected command output to mention saved log, got: %s", output.String())
+	}
+}
+
+func TestReviewCommand_LogWriteFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	vault := t.TempDir()
+	protected := filepath.Join(vault, "protected")
+	if err := os.WriteFile(protected, []byte("occupied"), 0o644); err != nil {
+		t.Fatalf("failed to create blocking file: %v", err)
+	}
+
+	notePath := filepath.Join(vault, "retro.md")
+	if err := os.WriteFile(notePath, []byte("# Retro\n"), 0o644); err != nil {
+		t.Fatalf("failed to write note: %v", err)
+	}
+	old := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(notePath, old, old); err != nil {
+		t.Fatalf("failed to set note mod time: %v", err)
+	}
+
+	cfg := &config.Config{
+		Workspaces: map[string]*config.Workspace{
+			"default": {
+				VaultDir:  vault,
+				NamedPins: config.PinMap{"review": "protected"},
+			},
+		},
+		CurrentWorkspace: "default",
+	}
+	if err := cfg.ActivateWorkspace("default"); err != nil {
+		t.Fatalf("failed to activate workspace: %v", err)
+	}
+
+	tmpl, err := templater.NewTemplater(cfg.MustWorkspace())
+	if err != nil {
+		t.Fatalf("failed to create templater: %v", err)
+	}
+
+	st := &state.State{Config: cfg, Workspace: cfg.MustWorkspace(), WorkspaceName: cfg.CurrentWorkspace, Templater: tmpl, Vault: vault}
+
+	cmd := NewCmdReview(st)
+	cmd.SetArgs([]string{"--log-path", "protected"})
+	cmd.SetIn(strings.NewReader("done\ndone\ndone\n"))
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error when log directory unavailable")
+	}
+	if !strings.Contains(err.Error(), "prepare review log directory") {
+		t.Fatalf("expected error to mention directory preparation, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add shared helpers in internal/review to resolve the log directory and render checklist outputs
- update the review CLI to accept a --log-path option, persist markdown logs, and announce the saved path
- switch the TUI review save flow to reuse the shared writer and cover the behaviour with new tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d96a2195548325a2edeef431c5465a