### PR TITLE
Add workspace review configuration and defaults

### DIFF
--- a/internal/review/log.go
+++ b/internal/review/log.go
@@ -11,11 +11,14 @@ import (
 	"github.com/Paintersrp/an/internal/templater"
 )
 
-var filenameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9\-]+`)
+var (
+	filenameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9\-]+`)
+	defaultLogDir     = "reviews"
+)
 
 // EnsureLogDir resolves and creates the directory used for persisted review logs.
 // The configured path may be absolute or relative to the vault. When empty, the
-// default ".an/review" directory inside the vault is used. The resolved
+// default "reviews" directory inside the vault is used. The resolved
 // directory must live inside the vault.
 func EnsureLogDir(vault, configured string) (string, string, error) {
 	vault = strings.TrimSpace(vault)
@@ -25,7 +28,7 @@ func EnsureLogDir(vault, configured string) (string, string, error) {
 
 	dir := strings.TrimSpace(configured)
 	if dir == "" {
-		dir = filepath.Join(vault, ".an", "review")
+		dir = filepath.Join(vault, defaultLogDir)
 	} else if !filepath.IsAbs(dir) {
 		dir = filepath.Join(vault, dir)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,6 +20,7 @@ type State struct {
 	Config        *config.Config
 	Workspace     *config.Workspace
 	WorkspaceName string
+	Review        config.ReviewConfig
 	Templater     *templater.Templater
 	Handler       *handler.FileHandler
 	ViewManager   *views.ViewManager
@@ -102,6 +103,7 @@ func NewState(workspaceOverride string) (*State, error) {
 		Config:        cfg,
 		Workspace:     ws,
 		WorkspaceName: cfg.CurrentWorkspace,
+		Review:        ws.Review,
 		Templater:     t,
 		Handler:       h,
 		ViewManager:   vm,

--- a/internal/tui/review/save.go
+++ b/internal/tui/review/save.go
@@ -58,7 +58,10 @@ func ensureReviewDir(st *state.State) (string, string, error) {
 	vault := strings.TrimSpace(st.Vault)
 	configured := ""
 	if st.Workspace != nil {
-		configured = st.Workspace.NamedPins["review"]
+		if !st.Workspace.Review.Enable {
+			return "", "", errors.New("review rituals are disabled for this workspace")
+		}
+		configured = st.Workspace.Review.Directory
 	}
 	return reviewsvc.EnsureLogDir(vault, configured)
 }

--- a/pkg/cmd/review/review_test.go
+++ b/pkg/cmd/review/review_test.go
@@ -39,8 +39,8 @@ func TestReviewCommand_WritesLog(t *testing.T) {
 	cfg := &config.Config{
 		Workspaces: map[string]*config.Workspace{
 			"default": {
-				VaultDir:  vault,
-				NamedPins: config.PinMap{"review": "logs"},
+				VaultDir: vault,
+				Review:   config.ReviewConfig{Enable: true, Directory: "logs"},
 			},
 		},
 		CurrentWorkspace: "default",
@@ -54,7 +54,7 @@ func TestReviewCommand_WritesLog(t *testing.T) {
 		t.Fatalf("failed to create templater: %v", err)
 	}
 
-	st := &state.State{Config: cfg, Workspace: cfg.MustWorkspace(), WorkspaceName: cfg.CurrentWorkspace, Templater: tmpl, Vault: vault}
+	st := &state.State{Config: cfg, Workspace: cfg.MustWorkspace(), WorkspaceName: cfg.CurrentWorkspace, Review: cfg.MustWorkspace().Review, Templater: tmpl, Vault: vault}
 
 	cmd := NewCmdReview(st)
 	cmd.SetArgs([]string{})
@@ -129,8 +129,8 @@ func TestReviewCommand_LogWriteFailure(t *testing.T) {
 	cfg := &config.Config{
 		Workspaces: map[string]*config.Workspace{
 			"default": {
-				VaultDir:  vault,
-				NamedPins: config.PinMap{"review": "protected"},
+				VaultDir: vault,
+				Review:   config.ReviewConfig{Enable: true, Directory: "protected"},
 			},
 		},
 		CurrentWorkspace: "default",
@@ -144,7 +144,7 @@ func TestReviewCommand_LogWriteFailure(t *testing.T) {
 		t.Fatalf("failed to create templater: %v", err)
 	}
 
-	st := &state.State{Config: cfg, Workspace: cfg.MustWorkspace(), WorkspaceName: cfg.CurrentWorkspace, Templater: tmpl, Vault: vault}
+	st := &state.State{Config: cfg, Workspace: cfg.MustWorkspace(), WorkspaceName: cfg.CurrentWorkspace, Review: cfg.MustWorkspace().Review, Templater: tmpl, Vault: vault}
 
 	cmd := NewCmdReview(st)
 	cmd.SetArgs([]string{"--log-path", "protected"})


### PR DESCRIPTION
## Summary
- add a configurable review section to workspaces with sensible defaults and YAML/JSON wiring
- surface the review settings in state, CLI, and TUI flows while guarding commands when disabled
- switch review logs to a vault-relative `reviews` directory and add regression coverage for parsing, defaults, and overrides

## Testing
- go test ./internal/config ./internal/review ./internal/tui/review ./pkg/cmd/review

------
https://chatgpt.com/codex/tasks/task_e_68d96c97d59c8325b8a89080479b9e78