### PR TITLE
Document capture rule automation and dry-run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ an capture --template project-release
 The capture wizard works with workspace-defined views and any template-specific metadata. You can skip the preview step with
 `--no-preview` or pre-fill values such as `--title` and `--view` when scripting.
 
+Capture rules defined in your workspace configuration can also pre-populate tags and front matter before the note hits disk.
+Rules match on template names and optional upstream prefixes, making it easy to apply consistent metadata for release notes,
+meeting logs, or any other templated workflow. If a rule marks a clipboard requirement it only fires when a non-empty clipboard
+value is present, which is perfect for "paste into note" shortcuts.
+
+Any tags you enter manually are deduplicated alongside the rule-provided set so you can confidently re-type common keywords
+without worrying about duplicates in front matter. When you just want to inspect the metadata overlay, run `an capture --dry-run`
+to see the merged tags and front matter preview without creating a file. See [Capture rules & automation](docs/capture-rules.md)
+for configuration examples.
+
 ## Testing
 
 Run the unit suite before sending a pull request to confirm core flows still pass:

--- a/docs/capture-rules.md
+++ b/docs/capture-rules.md
@@ -1,0 +1,69 @@
+# Capture rules & automation
+
+Capture rules live inside each workspace configuration in `~/.an/cfg.yaml`. They
+run during `an capture` after you answer the interactive prompts but before the
+note is written, letting you inject tags or front matter based on the template,
+upstream target, or clipboard state.
+
+```yaml
+workspaces:
+  default:
+    vaultdir: /Users/me/notes
+    editor: nvim
+    capture:
+      rules:
+        - match:
+            template: project-release
+          action:
+            tags: [release, status/inbox]
+            front_matter:
+              status: drafted
+              reviewer: qa-team
+```
+
+The example above applies whenever the `project-release` template is selected.
+It overlays two tags and assigns front matter values before the note opens in
+your editor.
+
+## Matching strategies
+
+Every rule can include either matcher:
+
+- `match.template` limits the rule to a specific template name. Omit the field
+to apply it to every template.
+- `match.upstream_prefix` checks the upstream note path you provide to the
+capture wizard. Use it to scope rules to projects, e.g. only when linking to
+`research/` folders.
+
+If both matchers are present, they must succeed for the rule to fire. Multiple
+rules can fire for the same capture and their metadata is merged in the order
+they appear in the configuration.
+
+## Clipboard-aware notes
+
+Set `action.clipboard: true` to require a non-empty clipboard before a rule
+runs. This is handy for "clip and capture" flows so empty clipboards do not add
+noise:
+
+```yaml
+    capture:
+      rules:
+        - match:
+            upstream_prefix: inbox/
+          action:
+            clipboard: true
+            tags: [source/clipboard]
+            front_matter:
+              collected_via: clipboard
+```
+
+When the clipboard is empty the rule is skipped, but any other rules that do not
+check the clipboard still apply.
+
+## Tag & front matter deduplication
+
+Manual tags entered during capture are merged with rule-driven tags while
+preserving order and removing duplicates. Front matter values from later rules
+override earlier ones, making it simple to compose defaults with targeted
+overrides. Combine these rules with `an capture --dry-run` to preview the final
+metadata without writing a file.

--- a/docs/expansion-roadmap.md
+++ b/docs/expansion-roadmap.md
@@ -27,7 +27,7 @@ This document captures medium-term feature expansions for the Atomic Notes CLI a
 **Tasks.**
 - [x] Design a template manifest format (YAML or TOML) and parser to populate default note scaffolds.
 - [x] Implement a `an capture --template <name>` subcommand that uses the manifest and still respects configured editors.
-- [ ] Add optional auto-tagging rules (e.g., based on capture source) that update front matter before the file hits disk.
+- [x] Add optional auto-tagging rules (e.g., based on capture source) that update front matter before the file hits disk.
 - [x] Document the capture workflow in the README with examples and troubleshooting tips.
 
 ## 3. Task-focused agenda mode


### PR DESCRIPTION
## Summary
- describe how capture rules inject tags/front matter, manual dedupe, and the dry-run preview in the README
- add a capture rules configuration guide with template, upstream, and clipboard-aware examples
- mark the roadmap auto-tagging checkbox now that the feature is documented and available

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d98182d96c8325889492f624d04790