### PR TITLE
Add preview link navigation palette to notes TUI

### DIFF
--- a/internal/tui/notes/keys.go
+++ b/internal/tui/notes/keys.go
@@ -12,6 +12,7 @@ type listKeyMap struct {
 	quit                  key.Binding
 	changeView            key.Binding
 	filterPalette         key.Binding
+	previewPalette        key.Binding
 	rename                key.Binding
 	create                key.Binding
 	copy                  key.Binding
@@ -76,6 +77,10 @@ func newListKeyMap() *listKeyMap {
 		filterPalette: key.NewBinding(
 			key.WithKeys("F"),
 			key.WithHelp("F", "filters"),
+		),
+		previewPalette: key.NewBinding(
+			key.WithKeys("ctrl+l"),
+			key.WithHelp("ctrl+l", "preview links"),
 		),
 		rename: key.NewBinding(
 			key.WithKeys("R"),
@@ -164,6 +169,7 @@ func (m listKeyMap) fullHelp() []key.Binding {
 		m.editInline,
 		m.quickCapture,
 		m.filterPalette,
+		m.previewPalette,
 		m.rename,
 		m.copy,
 		m.changeView,

--- a/internal/tui/notes/preview.go
+++ b/internal/tui/notes/preview.go
@@ -53,6 +53,28 @@ func buildPreviewContext(
 	return ctx
 }
 
+func previewContextSummary(ctx previewContext) string {
+	outboundCount := len(ctx.Outbound)
+	backlinkCount := len(ctx.Backlinks)
+	neighbourCount := len(ctx.QueueNeighbours)
+
+	summary := fmt.Sprintf(
+		"Links: %d outbound · %d backlinks",
+		outboundCount,
+		backlinkCount,
+	)
+
+	if neighbourCount > 0 {
+		summary = fmt.Sprintf(
+			"%s · %d queue neighbours",
+			summary,
+			neighbourCount,
+		)
+	}
+
+	return summary
+}
+
 func formatPreviewContext(ctx previewContext, vault string) string {
 	outboundCount := len(ctx.Outbound)
 	backlinkCount := len(ctx.Backlinks)
@@ -62,18 +84,7 @@ func formatPreviewContext(ctx previewContext, vault string) string {
 		return "No links yet"
 	}
 
-	summary := fmt.Sprintf(
-		"Links: %d outbound · %d backlinks",
-		outboundCount,
-		backlinkCount,
-	)
-	if neighbourCount > 0 {
-		summary = fmt.Sprintf(
-			"%s · %d queue neighbours",
-			summary,
-			neighbourCount,
-		)
-	}
+	summary := previewContextSummary(ctx)
 
 	sections := []struct {
 		title string

--- a/internal/tui/notes/styles.go
+++ b/internal/tui/notes/styles.go
@@ -59,6 +59,32 @@ var (
 				Border(lipgloss.NormalBorder(), false, false, false, true).
 				BorderForeground(lipgloss.Color("#334455"))
 
+	previewPaletteStyle = lipgloss.NewStyle().
+				MarginLeft(1).
+				Border(lipgloss.NormalBorder(), false, false, false, true).
+				BorderForeground(lipgloss.Color("#334455"))
+
+	previewPaletteTitleStyle = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color("#0AF"))
+
+	previewPaletteHeaderStyle = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color("#89dceb"))
+
+	previewPaletteCursorStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("#FFF")).
+					Background(lipgloss.Color("#0AF"))
+
+	previewPaletteInactiveStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("#cdd6f4"))
+
+	previewPaletteEmptyStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("#6c7086"))
+
+	previewPaletteHelpStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#94e2d5"))
+
 	linkSelectStyle = lipgloss.NewStyle().MarginLeft(1).
 			Border(lipgloss.NormalBorder(), false, false, false, true).
 			BorderForeground(lipgloss.Color("#334455"))


### PR DESCRIPTION
## Summary
- add a ctrl+l shortcut to open a preview link navigation palette in the notes view
- track the preview context so the palette and status bar can show outbound/backlink/queue links and open or focus notes appropriately
- cover the new palette interactions with unit tests

## Testing
- go test ./internal/tui/notes

------
https://chatgpt.com/codex/tasks/task_e_68d983f9695c8325aaf642a1a32708df