### PR TITLE
Switch preview palette toggle to L key

### DIFF
--- a/internal/tui/notes/keys.go
+++ b/internal/tui/notes/keys.go
@@ -79,8 +79,8 @@ func newListKeyMap() *listKeyMap {
 			key.WithHelp("F", "filters"),
 		),
 		previewPalette: key.NewBinding(
-			key.WithKeys("ctrl+l"),
-			key.WithHelp("ctrl+l", "preview links"),
+			key.WithKeys("L"),
+			key.WithHelp("L", "preview links"),
 		),
 		rename: key.NewBinding(
 			key.WithKeys("R"),

--- a/internal/tui/notes/notes.go
+++ b/internal/tui/notes/notes.go
@@ -2342,12 +2342,15 @@ func (m *NoteListModel) handlePreviewPaletteUpdate(msg tea.KeyMsg) (tea.Model, t
 			return m, nil
 		}
 		return m, m.focusListOnPreviewLink(link.path)
-	case tea.KeyEsc, tea.KeyCtrlC, tea.KeyCtrlL:
+	case tea.KeyEsc, tea.KeyCtrlC:
 		m.previewPaletteOpen = false
 		return m, nil
 	}
 
 	switch msg.String() {
+	case "L", "l":
+		m.previewPaletteOpen = false
+		return m, nil
 	case "j":
 		m.movePreviewPaletteCursor(1)
 		return m, nil

--- a/internal/tui/notes/notes_test.go
+++ b/internal/tui/notes/notes_test.go
@@ -229,7 +229,7 @@ func TestPreviewPaletteToggleAndView(t *testing.T) {
 
 	noteModel = drainNoteCmd(t, noteModel, cmd)
 
-	if cmd, handled := noteModel.handleDefaultUpdate(tea.KeyMsg{Type: tea.KeyCtrlL}); !handled {
+	if cmd, handled := noteModel.handleDefaultUpdate(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}}); !handled {
 		t.Fatalf("expected preview palette toggle to be handled")
 	} else if cmd != nil {
 		noteModel = drainNoteCmd(t, noteModel, cmd)
@@ -278,7 +278,7 @@ func TestPreviewPaletteTabFocusesList(t *testing.T) {
 
 	noteModel = drainNoteCmd(t, noteModel, cmd)
 
-	if cmd, handled := noteModel.handleDefaultUpdate(tea.KeyMsg{Type: tea.KeyCtrlL}); !handled {
+	if cmd, handled := noteModel.handleDefaultUpdate(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}}); !handled {
 		t.Fatalf("expected preview palette toggle to be handled")
 	} else if cmd != nil {
 		noteModel = drainNoteCmd(t, noteModel, cmd)

--- a/internal/tui/notes/submodels/filter.go
+++ b/internal/tui/notes/submodels/filter.go
@@ -138,9 +138,6 @@ func (m *FilterModel) Update(msg tea.Msg) (tea.Cmd, bool) {
 				return m.selectionChangedCmd(), true
 			}
 			return nil, true
-		case tea.KeyCtrlL:
-			m.clearSelections()
-			return m.selectionChangedCmd(), true
 		case tea.KeyEnter:
 			fallthrough
 		case tea.KeyEsc:
@@ -158,6 +155,9 @@ func (m *FilterModel) Update(msg tea.Msg) (tea.Cmd, bool) {
 			return nil, true
 		case "q":
 			return func() tea.Msg { return FilterClosedMsg{} }, true
+		case "l", "L":
+			m.clearSelections()
+			return m.selectionChangedCmd(), true
 		}
 	}
 
@@ -188,7 +188,7 @@ func (m *FilterModel) View() string {
 		}
 	}
 
-	help := "space toggle • ctrl+l clear • enter/q close"
+	help := "space toggle • L clear • enter/q close"
 	lines = append(lines, "", filterHelpStyle.Render(help))
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary
- remap the preview palette binding to use the L key instead of Ctrl+L
- update palette and filter handlers/help text to close and clear on the new key
- refresh notes tests to assert the new binding

## Testing
- go test ./internal/tui/notes

------
https://chatgpt.com/codex/tasks/task_e_68d994b7d97083258b913f2e8161693d