### PR TITLE
Add search index heartbeat status updates

### DIFF
--- a/internal/state/index_status.go
+++ b/internal/state/index_status.go
@@ -1,0 +1,50 @@
+package state
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// IndexStatsMsg notifies subscribers that the root status line was refreshed
+// using the latest search index statistics.
+type IndexStatsMsg struct {
+	Line string
+}
+
+// IndexHeartbeatCmd polls the index service for lightweight statistics,
+// updates the shared root status line, and returns a message that consumers can
+// use to trigger rerenders.
+func (s *State) IndexHeartbeatCmd() tea.Cmd {
+	if s == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		line := formatIndexStatus(s.Index)
+		if s.RootStatus != nil {
+			s.RootStatus.Set(line)
+		}
+		return IndexStatsMsg{Line: line}
+	}
+}
+
+func formatIndexStatus(svc IndexService) string {
+	if svc == nil {
+		return ""
+	}
+
+	stats := svc.Stats()
+	parts := []string{fmt.Sprintf("Idx: pending %d", stats.Pending)}
+	if !stats.LastRebuild.IsZero() {
+		parts = append(parts, fmt.Sprintf("rebuilt %s", formatRebuildTime(stats.LastRebuild)))
+	}
+
+	return strings.Join(parts, " · ")
+}
+
+func formatRebuildTime(t time.Time) string {
+	return t.Local().Format("15:04")
+}

--- a/internal/state/index_status_test.go
+++ b/internal/state/index_status_test.go
@@ -1,0 +1,97 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/an/internal/search"
+	indexsvc "github.com/Paintersrp/an/internal/services/index"
+)
+
+type stubIndexService struct {
+	stats indexsvc.Stats
+}
+
+func (s stubIndexService) AcquireSnapshot() (*search.Index, error) { return nil, nil }
+func (s stubIndexService) QueueUpdate(string)                      {}
+func (s stubIndexService) Stats() indexsvc.Stats                   { return s.stats }
+func (s stubIndexService) Close() error                            { return nil }
+
+func TestFormatIndexStatusIncludesRebuild(t *testing.T) {
+	t.Parallel()
+
+	svc := stubIndexService{stats: indexsvc.Stats{
+		Pending:     3,
+		LastRebuild: time.Date(2024, time.March, 5, 17, 42, 0, 0, time.UTC),
+	}}
+
+	got := formatIndexStatus(svc)
+	want := "Idx: pending 3 · rebuilt 17:42"
+	if got != want {
+		t.Fatalf("formatIndexStatus mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestFormatIndexStatusOmitRebuildWhenZero(t *testing.T) {
+	t.Parallel()
+
+	svc := stubIndexService{stats: indexsvc.Stats{Pending: 0}}
+	got := formatIndexStatus(svc)
+	want := "Idx: pending 0"
+	if got != want {
+		t.Fatalf("formatIndexStatus mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestIndexHeartbeatClearsWhenServiceNil(t *testing.T) {
+	t.Parallel()
+
+	st := &State{RootStatus: &RootStatus{}}
+	st.RootStatus.Set("stale")
+
+	cmd := st.IndexHeartbeatCmd()
+	if cmd == nil {
+		t.Fatalf("expected heartbeat command")
+	}
+
+	msg := cmd()
+	statsMsg, ok := msg.(IndexStatsMsg)
+	if !ok {
+		t.Fatalf("expected IndexStatsMsg, got %T", msg)
+	}
+
+	if statsMsg.Line != "" {
+		t.Fatalf("expected blank line when index unavailable, got %q", statsMsg.Line)
+	}
+
+	if got := st.RootStatus.Value(); got != "" {
+		t.Fatalf("expected root status to be cleared, got %q", got)
+	}
+}
+
+func TestIndexHeartbeatUpdatesStatus(t *testing.T) {
+	t.Parallel()
+
+	svc := stubIndexService{stats: indexsvc.Stats{Pending: 7}}
+	st := &State{RootStatus: &RootStatus{}, Index: svc}
+
+	cmd := st.IndexHeartbeatCmd()
+	if cmd == nil {
+		t.Fatalf("expected heartbeat command")
+	}
+
+	msg := cmd()
+	statsMsg, ok := msg.(IndexStatsMsg)
+	if !ok {
+		t.Fatalf("expected IndexStatsMsg, got %T", msg)
+	}
+
+	want := "Idx: pending 7"
+	if statsMsg.Line != want {
+		t.Fatalf("expected %q, got %q", want, statsMsg.Line)
+	}
+
+	if got := st.RootStatus.Value(); got != want {
+		t.Fatalf("expected root status %q, got %q", want, got)
+	}
+}

--- a/internal/tui/notes/root_test.go
+++ b/internal/tui/notes/root_test.go
@@ -222,8 +222,8 @@ func TestRootHeaderOmittedWhenNoViews(t *testing.T) {
 		}
 	}
 
-	if st.RootStatus.Line != "" {
-		t.Fatalf("expected root status line to be empty, got %q", st.RootStatus.Line)
+	if got := st.RootStatus.Value(); got != "" {
+		t.Fatalf("expected root status line to be empty, got %q", got)
 	}
 }
 

--- a/internal/tui/tasks/model.go
+++ b/internal/tui/tasks/model.go
@@ -173,6 +173,13 @@ func (i listItem) FilterValue() string {
 }
 
 func (m *Model) Init() tea.Cmd {
+	if m.state == nil {
+		return nil
+	}
+
+	if cmd := m.state.IndexHeartbeatCmd(); cmd != nil {
+		return cmd
+	}
 	return nil
 }
 
@@ -207,6 +214,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.resetFilters()
 			return m, m.applyFilters()
 		}
+	case state.IndexStatsMsg:
+		if m.state != nil && m.state.Watcher != nil {
+			return m, m.state.Watcher.Start()
+		}
+		return m, nil
 	}
 
 	var cmd tea.Cmd
@@ -263,7 +275,7 @@ func (m *Model) rootStatusLine() string {
 	if m.state == nil || m.state.RootStatus == nil {
 		return ""
 	}
-	return m.state.RootStatus.Line
+	return m.state.RootStatus.Value()
 }
 
 func rootStatusSuffix(view string, width int, status, gap string) string {


### PR DESCRIPTION
## Summary
- add a thread-safe root status heartbeat command that polls index stats and updates the shared status line
- extend the vault watcher with a periodic heartbeat trigger and queue pending filesystem events so both messages are delivered
- refresh the notes and tasks UIs when the index status message arrives and cover the new formatting behaviour with tests

## Testing
- go test -v ./...


------
https://chatgpt.com/codex/tasks/task_e_68d9a16419c483259b3866663e4c2f85