### PR TITLE
Preserve whitespace when extracting task metadata

### DIFF
--- a/internal/parser/task_metadata.go
+++ b/internal/parser/task_metadata.go
@@ -76,7 +76,7 @@ func ExtractTaskMetadata(content string) (string, TaskMetadata) {
 	}
 
 	cleaned = backlinkPattern.ReplaceAllString(cleaned, "")
-	cleaned = strings.TrimSpace(strings.Join(strings.Fields(cleaned), " "))
+	cleaned = strings.TrimSpace(cleaned)
 
 	return cleaned, metadata
 }

--- a/internal/parser/task_metadata_test.go
+++ b/internal/parser/task_metadata_test.go
@@ -35,6 +35,28 @@ func TestExtractTaskMetadataParsesTokens(t *testing.T) {
 	}
 }
 
+func TestExtractTaskMetadataPreservesWhitespace(t *testing.T) {
+	content := `- [ ] Update docs @due(2024-12-01)
+    Continue discussion with team
+        subpoint details @priority(high)`
+
+	cleaned, meta := ExtractTaskMetadata(content)
+
+	expected := `- [ ] Update docs 
+    Continue discussion with team
+        subpoint details`
+	if cleaned != expected {
+		t.Fatalf("expected cleaned content to preserve whitespace, got %q", cleaned)
+	}
+
+	if meta.DueDate == nil {
+		t.Fatalf("expected due metadata to be parsed")
+	}
+	if meta.Priority != "high" {
+		t.Fatalf("expected priority metadata to be parsed, got %q", meta.Priority)
+	}
+}
+
 func TestParseDateRecognizesKeywords(t *testing.T) {
 	today := time.Now()
 	parsed, ok := parseDate("today")


### PR DESCRIPTION
## Summary
- update task metadata extraction to avoid normalizing internal whitespace
- add a unit test that verifies multi-line content keeps its original indentation after metadata removal

## Testing
- go test ./internal/parser -run TestExtractTaskMetadataPreservesWhitespace -count=1 -v


------
https://chatgpt.com/codex/tasks/task_e_68d9b35008e883258d060fb0b52a7ce0