### PR TITLE
Add backlink graph pane to note list view

### DIFF
--- a/internal/tui/notes/keys.go
+++ b/internal/tui/notes/keys.go
@@ -13,6 +13,7 @@ type listKeyMap struct {
 	changeView            key.Binding
 	filterPalette         key.Binding
 	previewPalette        key.Binding
+	toggleGraphPane       key.Binding
 	rename                key.Binding
 	create                key.Binding
 	copy                  key.Binding
@@ -81,6 +82,10 @@ func newListKeyMap() *listKeyMap {
 		previewPalette: key.NewBinding(
 			key.WithKeys("L"),
 			key.WithHelp("L", "preview links"),
+		),
+		toggleGraphPane: key.NewBinding(
+			key.WithKeys("g"),
+			key.WithHelp("g", "backlink graph"),
 		),
 		rename: key.NewBinding(
 			key.WithKeys("R"),
@@ -170,6 +175,7 @@ func (m listKeyMap) fullHelp() []key.Binding {
 		m.quickCapture,
 		m.filterPalette,
 		m.previewPalette,
+		m.toggleGraphPane,
 		m.rename,
 		m.copy,
 		m.changeView,

--- a/internal/tui/notes/styles.go
+++ b/internal/tui/notes/styles.go
@@ -64,25 +64,54 @@ var (
 				Border(lipgloss.NormalBorder(), false, false, false, true).
 				BorderForeground(lipgloss.Color("#334455"))
 
+	graphPaneStyle = lipgloss.NewStyle().
+			MarginLeft(1).
+			Border(lipgloss.NormalBorder(), false, false, false, true).
+			BorderForeground(lipgloss.Color("#334455"))
+
 	previewPaletteTitleStyle = lipgloss.NewStyle().
 					Bold(true).
 					Foreground(lipgloss.Color("#0AF"))
+
+	graphPaneTitleStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#0AF"))
 
 	previewPaletteHeaderStyle = lipgloss.NewStyle().
 					Bold(true).
 					Foreground(lipgloss.Color("#89dceb"))
 
+	graphPaneHeaderStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#89dceb"))
+
 	previewPaletteCursorStyle = lipgloss.NewStyle().
 					Foreground(lipgloss.Color("#FFF")).
 					Background(lipgloss.Color("#0AF"))
 
+	graphPaneCursorStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#FFF")).
+				Background(lipgloss.Color("#0AF"))
+
 	previewPaletteInactiveStyle = lipgloss.NewStyle().
 					Foreground(lipgloss.Color("#cdd6f4"))
+
+	graphPaneInactiveStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#cdd6f4"))
+
+	graphPaneQueueStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#f9e2af"))
 
 	previewPaletteEmptyStyle = lipgloss.NewStyle().
 					Foreground(lipgloss.Color("#6c7086"))
 
+	graphPaneEmptyStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#6c7086"))
+
 	previewPaletteHelpStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#94e2d5"))
+
+	graphPaneHelpStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#94e2d5"))
 
 	linkSelectStyle = lipgloss.NewStyle().MarginLeft(1).


### PR DESCRIPTION
## Summary
- extend the note list model with backlink graph state and queue-aware helpers that rebuild alongside preview updates
- add a `g` keybinding and update default handling so the backlink graph pane can be opened, navigated, and filtered
- render the backlink graph pane with dedicated styling, including queue indicators and contextual help

## Testing
- go test ./... *(interrupted locally due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b97041a48325abbdc09f299a4e79