### PR TITLE
Support capture rule field prefills

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ type CaptureAction struct {
 	Clipboard   bool           `yaml:"clipboard"    json:"clipboard"`
 	Tags        []string       `yaml:"tags"         json:"tags"`
 	FrontMatter map[string]any `yaml:"front_matter" json:"front_matter"`
+	Fields      map[string]any `yaml:"fields"       json:"fields"`
 }
 
 type CaptureRule struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -229,6 +229,7 @@ func TestLoadCaptureRules(t *testing.T) {
 								"clipboard":    true,
 								"tags":         []any{"foo", "bar"},
 								"front_matter": map[string]any{"status": "wip", "priority": 2},
+								"fields":       map[string]any{"source": "rule"},
 							},
 						},
 					},
@@ -266,6 +267,11 @@ func TestLoadCaptureRules(t *testing.T) {
 	wantFrontMatter := map[string]any{"status": "wip", "priority": 2}
 	if !reflect.DeepEqual(rule.Action.FrontMatter, wantFrontMatter) {
 		t.Fatalf("expected front matter %#v, got %#v", wantFrontMatter, rule.Action.FrontMatter)
+	}
+
+	wantFields := map[string]any{"source": "rule"}
+	if !reflect.DeepEqual(rule.Action.Fields, wantFields) {
+		t.Fatalf("expected fields %#v, got %#v", wantFields, rule.Action.Fields)
 	}
 }
 
@@ -414,6 +420,7 @@ func TestCaptureRulesRoundTrip(t *testing.T) {
 								"clipboard":    true,
 								"tags":         []any{"foo", "bar"},
 								"front_matter": map[string]any{"status": "wip", "priority": 2},
+								"fields":       map[string]any{"source": "rule"},
 							},
 						},
 					},
@@ -450,6 +457,9 @@ func TestCaptureRulesRoundTrip(t *testing.T) {
 				FrontMatter: map[string]any{
 					"status":   "wip",
 					"priority": 2,
+				},
+				Fields: map[string]any{
+					"source": "rule",
 				},
 			},
 		},

--- a/internal/tui/notes/submodels/form.go
+++ b/internal/tui/notes/submodels/form.go
@@ -301,7 +301,7 @@ func (m FormModel) handleSubmit() FormModel {
 		return m
 	}
 
-	metadata, err := note.CollectTemplateMetadataNonInteractive(m.state.Templater, tmpl)
+	metadata, err := note.CollectTemplateMetadataNonInteractive(m.state.Templater, tmpl, nil)
 	if err != nil {
 		fmt.Printf("error collecting template metadata: %v\n", err)
 		return m

--- a/pkg/cmd/capture/capture_rules_test.go
+++ b/pkg/cmd/capture/capture_rules_test.go
@@ -26,6 +26,7 @@ func TestResolveCaptureMetadataOverlappingRules(t *testing.T) {
 						Action: config.CaptureAction{
 							Tags:        []string{"global", "link"},
 							FrontMatter: map[string]any{"status": "general"},
+							Fields:      map[string]any{"status": "general"},
 						},
 					},
 					{
@@ -33,6 +34,7 @@ func TestResolveCaptureMetadataOverlappingRules(t *testing.T) {
 						Action: config.CaptureAction{
 							Tags:        []string{"daily", "link"},
 							FrontMatter: map[string]any{"status": "daily", "review": true},
+							Fields:      map[string]any{"status": "daily"},
 						},
 					},
 					{
@@ -40,6 +42,7 @@ func TestResolveCaptureMetadataOverlappingRules(t *testing.T) {
 						Action: config.CaptureAction{
 							Tags:        []string{"sync"},
 							FrontMatter: map[string]any{"status": "synced", "priority": 1},
+							Fields:      map[string]any{"status": "synced"},
 						},
 					},
 					{
@@ -47,6 +50,7 @@ func TestResolveCaptureMetadataOverlappingRules(t *testing.T) {
 							Clipboard:   true,
 							Tags:        []string{"clip", "sync"},
 							FrontMatter: map[string]any{"clipboard": "attached"},
+							Fields:      map[string]any{"origin": "clipboard"},
 						},
 					},
 				},
@@ -54,7 +58,7 @@ func TestResolveCaptureMetadataOverlappingRules(t *testing.T) {
 		},
 	}
 
-	tags, metadata, err := resolveCaptureMetadata(s, "daily", "obsidian://note")
+	tags, metadata, fields, err := resolveCaptureMetadata(s, "daily", "obsidian://note")
 	if err != nil {
 		t.Fatalf("resolveCaptureMetadata returned error: %v", err)
 	}
@@ -73,12 +77,20 @@ func TestResolveCaptureMetadataOverlappingRules(t *testing.T) {
 	if !reflect.DeepEqual(metadata, wantMetadata) {
 		t.Fatalf("expected metadata %#v, got %#v", wantMetadata, metadata)
 	}
+
+	wantFields := map[string]any{
+		"origin": "clipboard",
+		"status": "synced",
+	}
+	if !reflect.DeepEqual(fields, wantFields) {
+		t.Fatalf("expected fields %#v, got %#v", wantFields, fields)
+	}
 }
 
 func TestResolveCaptureMetadataNoRules(t *testing.T) {
 	s := &state.State{Workspace: &config.Workspace{}}
 
-	tags, metadata, err := resolveCaptureMetadata(s, "", "")
+	tags, metadata, fields, err := resolveCaptureMetadata(s, "", "")
 	if err != nil {
 		t.Fatalf("resolveCaptureMetadata returned error: %v", err)
 	}
@@ -87,6 +99,9 @@ func TestResolveCaptureMetadataNoRules(t *testing.T) {
 	}
 	if metadata != nil {
 		t.Fatalf("expected nil metadata, got %v", metadata)
+	}
+	if fields != nil {
+		t.Fatalf("expected nil fields, got %v", fields)
 	}
 }
 

--- a/pkg/cmd/capture/capture_test.go
+++ b/pkg/cmd/capture/capture_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestResolveCaptureMetadataNilWorkspace(t *testing.T) {
-	tags, metadata, err := resolveCaptureMetadata(nil, "daily", "")
+	tags, metadata, fields, err := resolveCaptureMetadata(nil, "daily", "")
 	if err != nil {
 		t.Fatalf("resolveCaptureMetadata returned error: %v", err)
 	}
@@ -19,6 +19,9 @@ func TestResolveCaptureMetadataNilWorkspace(t *testing.T) {
 	}
 	if metadata != nil {
 		t.Fatalf("expected nil metadata, got %v", metadata)
+	}
+	if fields != nil {
+		t.Fatalf("expected nil fields, got %v", fields)
 	}
 }
 
@@ -32,6 +35,7 @@ func TestResolveCaptureMetadataMergesRules(t *testing.T) {
 						Action: config.CaptureAction{
 							Tags:        []string{"foo"},
 							FrontMatter: map[string]any{"status": "wip"},
+							Fields:      map[string]any{"source": "seed"},
 						},
 					},
 					{
@@ -39,6 +43,7 @@ func TestResolveCaptureMetadataMergesRules(t *testing.T) {
 						Action: config.CaptureAction{
 							Tags:        []string{"foo", "bar"},
 							FrontMatter: map[string]any{"priority": 2},
+							Fields:      map[string]any{"source": "api"},
 						},
 					},
 				},
@@ -46,7 +51,7 @@ func TestResolveCaptureMetadataMergesRules(t *testing.T) {
 		},
 	}
 
-	tags, metadata, err := resolveCaptureMetadata(s, "daily", "obsidian://note")
+	tags, metadata, fields, err := resolveCaptureMetadata(s, "daily", "obsidian://note")
 	if err != nil {
 		t.Fatalf("resolveCaptureMetadata returned error: %v", err)
 	}
@@ -62,6 +67,13 @@ func TestResolveCaptureMetadataMergesRules(t *testing.T) {
 	}
 	if !reflect.DeepEqual(metadata, wantMetadata) {
 		t.Fatalf("expected metadata %#v, got %#v", wantMetadata, metadata)
+	}
+
+	wantFields := map[string]any{
+		"source": "api",
+	}
+	if !reflect.DeepEqual(fields, wantFields) {
+		t.Fatalf("expected fields %#v, got %#v", wantFields, fields)
 	}
 }
 
@@ -90,7 +102,7 @@ func TestResolveCaptureMetadataClipboard(t *testing.T) {
 		return "", nil
 	}
 
-	tags, _, err := resolveCaptureMetadata(s, "", "")
+	tags, _, _, err := resolveCaptureMetadata(s, "", "")
 	if err != nil {
 		t.Fatalf("resolveCaptureMetadata returned error: %v", err)
 	}
@@ -102,7 +114,7 @@ func TestResolveCaptureMetadataClipboard(t *testing.T) {
 		return "hello", nil
 	}
 
-	tags, _, err = resolveCaptureMetadata(s, "", "")
+	tags, _, _, err = resolveCaptureMetadata(s, "", "")
 	if err != nil {
 		t.Fatalf("resolveCaptureMetadata returned error: %v", err)
 	}
@@ -114,7 +126,7 @@ func TestResolveCaptureMetadataClipboard(t *testing.T) {
 		return "", errors.New("boom")
 	}
 
-	if _, _, err := resolveCaptureMetadata(s, "", ""); err == nil {
+	if _, _, _, err := resolveCaptureMetadata(s, "", ""); err == nil {
 		t.Fatalf("expected error when clipboard read fails")
 	}
 }


### PR DESCRIPTION
## Summary
- add capture rule field definitions to the configuration schema and tests
- merge capture rule fields alongside tags/front matter and prefill template prompts
- extend template metadata collection APIs to accept prefills and update call sites/tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d9c0d65c54832593d67f1cff5551e7