### PR TITLE
Add review history tab with log previews

### DIFF
--- a/internal/review/log.go
+++ b/internal/review/log.go
@@ -1,10 +1,13 @@
 package review
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -15,6 +18,17 @@ var (
 	filenameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9\-]+`)
 	defaultLogDir     = "reviews"
 )
+
+var timestampPattern = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z`)
+
+// LogMetadata captures the derived information about a persisted review log.
+type LogMetadata struct {
+	Path      string
+	Filename  string
+	Title     string
+	Timestamp time.Time
+	Preview   []string
+}
 
 // EnsureLogDir resolves and creates the directory used for persisted review logs.
 // The configured path may be absolute or relative to the vault. When empty, the
@@ -79,6 +93,10 @@ func WriteMarkdownLog(
 }
 
 func buildReviewFilename(manifest templater.TemplateManifest, ts time.Time) string {
+	return fmt.Sprintf("%s-%s", manifestSlug(manifest), ts.Format("2006-01-02"))
+}
+
+func manifestSlug(manifest templater.TemplateManifest) string {
 	name := strings.TrimSpace(manifest.Name)
 	if name == "" {
 		name = "review"
@@ -90,7 +108,7 @@ func buildReviewFilename(manifest templater.TemplateManifest, ts time.Time) stri
 	if name == "" {
 		name = "review"
 	}
-	return fmt.Sprintf("%s-%s", name, ts.Format("2006-01-02"))
+	return name
 }
 
 func renderReviewLogContent(
@@ -191,4 +209,219 @@ func appendReviewLog(path, content string) error {
 
 	_, err = file.WriteString(entry)
 	return err
+}
+
+// ListReviewLogs returns the metadata for review logs associated with the provided
+// manifest and mode key. Results are sorted by the embedded timestamp in the log
+// content when available (falling back to the file modification time) in
+// descending order.
+func ListReviewLogs(dir string, manifest templater.TemplateManifest, modeKey string) ([]LogMetadata, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	slug := strings.ToLower(manifestSlug(manifest))
+	mode := strings.ToLower(strings.TrimSpace(modeKey))
+
+	var logs []LogMetadata
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(strings.ToLower(name), ".md") {
+			continue
+		}
+
+		base := strings.TrimSuffix(name, filepath.Ext(name))
+		path := filepath.Join(dir, name)
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			if !matchesLogMode(base, "", slug, mode) {
+				continue
+			}
+			logs = append(logs, LogMetadata{
+				Path:      path,
+				Filename:  name,
+				Title:     defaultLogTitle(base),
+				Timestamp: info.ModTime().UTC(),
+			})
+			continue
+		}
+
+		text := string(content)
+		if !matchesLogMode(base, text, slug, mode) {
+			continue
+		}
+
+		lines := normalizeLogLines(text)
+		title := extractLogTitle(lines, base)
+		preview := extractLogPreview(lines, 5)
+		ts := extractLogTimestamp(lines, base, info.ModTime())
+
+		logs = append(logs, LogMetadata{
+			Path:      path,
+			Filename:  name,
+			Title:     title,
+			Timestamp: ts,
+			Preview:   preview,
+		})
+	}
+
+	sort.SliceStable(logs, func(i, j int) bool {
+		if logs[i].Timestamp.Equal(logs[j].Timestamp) {
+			return strings.Compare(logs[i].Filename, logs[j].Filename) > 0
+		}
+		return logs[i].Timestamp.After(logs[j].Timestamp)
+	})
+	return logs, nil
+}
+
+func matchesLogMode(name, content, slug, mode string) bool {
+	lowerName := strings.ToLower(name)
+	if slug != "" && strings.Contains(lowerName, slug) {
+		return true
+	}
+	if mode != "" && strings.Contains(lowerName, mode) {
+		return true
+	}
+
+	if strings.TrimSpace(content) == "" {
+		return slug == "" && mode == ""
+	}
+
+	lines := normalizeLogLines(content)
+	title := strings.ToLower(extractLogTitle(lines, name))
+	if slug != "" && strings.Contains(title, slug) {
+		return true
+	}
+	if mode != "" && strings.Contains(title, mode) {
+		return true
+	}
+	return false
+}
+
+func extractLogTitle(lines []string, fallback string) string {
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if i == 0 && strings.HasPrefix(line, "---") {
+			i = skipFrontMatter(lines, i)
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			candidate := strings.TrimSpace(strings.TrimLeft(line, "#"))
+			if idx := strings.Index(candidate, "—"); idx >= 0 {
+				candidate = strings.TrimSpace(candidate[:idx])
+			}
+			if candidate != "" {
+				return candidate
+			}
+		}
+		if !strings.HasPrefix(line, "#") {
+			break
+		}
+	}
+	return defaultLogTitle(fallback)
+}
+
+func extractLogPreview(lines []string, limit int) []string {
+	if limit <= 0 {
+		limit = 5
+	}
+	var preview []string
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "---") && (i == 0) {
+			i = skipFrontMatter(lines, i)
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		value := strings.TrimRight(line, " \t")
+		value = strings.TrimLeft(value, "\t")
+		preview = append(preview, strings.TrimSpace(value))
+		if len(preview) >= limit {
+			break
+		}
+	}
+	return preview
+}
+
+func extractLogTimestamp(lines []string, fallback string, mod time.Time) time.Time {
+	for _, line := range lines {
+		if match := timestampPattern.FindString(line); match != "" {
+			if ts, err := time.Parse(time.RFC3339, match); err == nil {
+				return ts.UTC()
+			}
+		}
+	}
+
+	if date := findDateSuffix(fallback); !date.IsZero() {
+		return date
+	}
+	return mod.UTC()
+}
+
+func skipFrontMatter(lines []string, index int) int {
+	for i := index + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return i
+		}
+	}
+	return len(lines)
+}
+
+func normalizeLogLines(content string) []string {
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	return strings.Split(normalized, "\n")
+}
+
+func defaultLogTitle(value string) string {
+	cleaned := strings.TrimSpace(value)
+	cleaned = strings.TrimSuffix(cleaned, ".md")
+	cleaned = strings.ReplaceAll(cleaned, "_", " ")
+	cleaned = strings.ReplaceAll(cleaned, "-", " ")
+	cleaned = strings.TrimSpace(cleaned)
+	if cleaned == "" {
+		return "Review"
+	}
+	parts := strings.Fields(cleaned)
+	for i, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		lower := strings.ToLower(part)
+		parts[i] = strings.ToUpper(lower[:1]) + lower[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func findDateSuffix(value string) time.Time {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) < len("2006-01-02") {
+		return time.Time{}
+	}
+	tail := trimmed[len(trimmed)-len("2006-01-02"):]
+	if ts, err := time.Parse("2006-01-02", tail); err == nil {
+		return ts
+	}
+	return time.Time{}
 }

--- a/internal/review/log_test.go
+++ b/internal/review/log_test.go
@@ -1,0 +1,96 @@
+package review
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Paintersrp/an/internal/templater"
+)
+
+func TestListReviewLogsFiltersAndSorts(t *testing.T) {
+	dir := t.TempDir()
+	manifest := templater.TemplateManifest{Name: "review-daily"}
+
+	// Log that should be filtered out (weekly mode).
+	writeLogFile(t, dir, "review-weekly-2024-01-01.md", "## review-weekly — 2024-01-01T10:00:00Z\n\nweekly content\n")
+
+	// Oldest daily entry with embedded timestamp.
+	oldest := "## review-daily — 2024-01-01T09:00:00Z\n\n### Checklist responses\n\n- **Clear capture inbox:** done\n"
+	writeLogFile(t, dir, "review-daily-2024-01-01.md", oldest)
+
+	// Entry without timestamp should fall back to filename-derived date.
+	mid := "## review-daily\n\nFollow up summary\n"
+	midPath := writeLogFile(t, dir, "review-daily-2024-01-02.md", mid)
+
+	// Manually edited entry without slug in filename but with front matter and heading.
+	manual := "---\ntitle: custom\n---\n## Daily Review Ritual — 2024-01-03T08:00:00Z\n\nFirst highlight\n- bullet line\n"
+	manualPath := writeLogFile(t, dir, "ritual-notes.md", manual)
+	// Ensure the file's mod time differs from embedded timestamp to ensure timestamp sorting is used.
+	olderMod := time.Date(2023, 12, 31, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(manualPath, olderMod, olderMod); err != nil {
+		t.Fatalf("failed to set manual log mod time: %v", err)
+	}
+
+	// Entry without timestamp or dated filename should fall back to mod time.
+	fallback := "Daily reflection summary\nCaptured a free-form insight.\n"
+	fallbackPath := writeLogFile(t, dir, "daily-notes.md", fallback)
+	fallbackTime := time.Date(2024, 1, 4, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(fallbackPath, fallbackTime, fallbackTime); err != nil {
+		t.Fatalf("failed to set fallback log mod time: %v", err)
+	}
+
+	logs, err := ListReviewLogs(dir, manifest, "daily")
+	if err != nil {
+		t.Fatalf("ListReviewLogs returned error: %v", err)
+	}
+
+	if len(logs) != 4 {
+		t.Fatalf("expected 4 daily logs, got %d", len(logs))
+	}
+
+	if logs[0].Path != fallbackPath {
+		t.Fatalf("expected log without timestamp to sort by mod time first, got %q", logs[0].Path)
+	}
+	if !logs[0].Timestamp.Equal(fallbackTime) {
+		t.Fatalf("expected fallback log timestamp to use mod time, got %v", logs[0].Timestamp)
+	}
+
+	if logs[1].Path != manualPath {
+		t.Fatalf("expected manual log to be second by timestamp, got %q", logs[1].Path)
+	}
+	if logs[1].Title != "Daily Review Ritual" {
+		t.Fatalf("expected manual log title to be derived from heading, got %q", logs[1].Title)
+	}
+	if len(logs[1].Preview) == 0 || logs[1].Preview[0] != "First highlight" {
+		t.Fatalf("expected preview to include manual content, got %#v", logs[1].Preview)
+	}
+	if len(logs[1].Preview) < 2 || logs[1].Preview[1] != "- bullet line" {
+		t.Fatalf("expected preview to preserve bullet formatting, got %#v", logs[1].Preview)
+	}
+
+	if logs[2].Path != midPath {
+		t.Fatalf("expected filename-dated log to sort next, got %q", logs[2].Path)
+	}
+	expectedDate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	if !logs[2].Timestamp.Equal(expectedDate) {
+		t.Fatalf("expected timestamp derived from filename, got %v", logs[2].Timestamp)
+	}
+
+	if logs[3].Title == "" {
+		t.Fatalf("expected oldest entry to have derived title, got empty string")
+	}
+	if logs[3].Timestamp.Year() != 2024 || logs[3].Timestamp.Day() != 1 {
+		t.Fatalf("expected oldest entry timestamp from embedded date, got %v", logs[3].Timestamp)
+	}
+}
+
+func writeLogFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write log %s: %v", name, err)
+	}
+	return path
+}

--- a/internal/tui/review/styles.go
+++ b/internal/tui/review/styles.go
@@ -13,4 +13,16 @@ var (
 
 	statusStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.AdaptiveColor{Light: "#0AF", Dark: "#0AF"})
+
+	tabActiveStyle = lipgloss.NewStyle().
+			Padding(0, 1).
+			Bold(true).
+			Underline(true)
+
+	tabInactiveStyle = lipgloss.NewStyle().
+				Padding(0, 1).
+				Faint(true)
+
+	historyPreviewStyle = lipgloss.NewStyle().
+				MarginLeft(4)
 )


### PR DESCRIPTION
## Summary
- add review log metadata helpers to list and preview markdown history entries
- integrate a history tab into the review TUI with key bindings, rendering, and async loading
- extend styles and tests to cover the history view and ensure logs refresh after saves

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d9c7bd11f8832585a3c953736b1df1